### PR TITLE
Harden the generic v2 API for review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,33 +1,62 @@
-name: Test
+name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+
+permissions:
+  contents: read
+  id-token: write
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   test:
+    name: Test with Go 1.26
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
-    - uses: actions/setup-go@v3
-      with:
-        go-version: 1.18
-    
-    - name: test
-      run: go test -coverprofile=coverage1.txt -covermode=atomic ./...
+      - uses: actions/setup-go@v7
+        with:
+          go-version: 1.26.x
+          check-latest: true
+          cache-dependency-path: go.sum
 
-    - name: fuzz
-      run: go test -coverprofile=coverage2.txt -covermode=atomic ./algo --fuzz-time=5m
+      - name: Verify dependencies
+        run: go mod verify
 
-    - name: upload codecov
-      uses: codecov/codecov-action@v2
-      with:
-        files: ./coverage1.txt, ./coverage2.txt
+      - name: Vet
+        run: go vet ./...
 
+      - name: Test
+        run: go test -race -covermode=atomic -coverprofile=coverage.txt ./...
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage.txt
+          fail_ci_if_error: true
+          use_oidc: true
+
+  fuzz:
+    name: Fuzz smoke tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v7
+        with:
+          go-version: 1.26.x
+          check-latest: true
+          cache-dependency-path: go.sum
+
+      - name: Fuzz Sort
+        run: go test ./algo -run=^$ -fuzz=^FuzzSort$ -fuzztime=10s
+
+      - name: Fuzz NthElement
+        run: go test ./algo -run=^$ -fuzz=^FuzzNthElement$ -fuzztime=10s

--- a/README.md
+++ b/README.md
@@ -1,258 +1,175 @@
 # iter
 
-**Note: I'm currently working on making it work with Go generics. For previous version, please check `v1` branch.**
+Generic Go implementations of the C++ standard algorithms.
 
-Go implementation of C++ STL iterators and algorithms.
+`iter` provides type-safe iterator contracts, more than 100 reusable
+algorithms, and convenient adapters for slices, strings, channels, and
+`container/list`.
 
-Less hand-written loops, more expressive code.
+> **Development status:** the generic v2 API is being prepared and has not been
+> released. Use the [`v1` branch](https://github.com/disksing/iter/tree/v1) for
+> the previous non-generic version.
 
-README translations: [简体中文](README_ZH.md)
+[简体中文](README_ZH.md)
 
-[![GoDoc](https://godoc.org/github.com/disksing/iter?status.svg)](https://godoc.org/github.com/disksing/iter)
-[![Build Status](https://travis-ci.com/disksing/iter.svg?branch=master)](https://travis-ci.com/disksing/iter)
+[![CI](https://github.com/disksing/iter/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/disksing/iter/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/disksing/iter/branch/master/graph/badge.svg)](https://codecov.io/gh/disksing/iter)
-[![Go Report Card](https://goreportcard.com/badge/github.com/disksing/iter)](https://goreportcard.com/report/github.com/disksing/iter)
 
-## Motivation
+## Requirements
 
-Although Go doesn't have generics, we deserve to have reuseable general algorithms. `iter` helps improving Go code in several ways:
+Go 1.26 or later.
 
-- Some simple loops are unlikely to be wrong or inefficient, but calling algorithm instead will **make the code more concise and easier to comprehend**. Such as [AllOf](https://godoc.org/github.com/disksing/iter#AllOf), [FindIf](https://godoc.org/github.com/disksing/iter#FindIf), [Accumulate](https://godoc.org/github.com/disksing/iter#Accumulate).
+## Packages
 
-- Some algorithms are not complicated, but it is not easy to write them correctly. **Reusing code makes them easier to reason for correctness**. Such as [Shuffle](https://godoc.org/github.com/disksing/iter#Shuffle), [Sample](https://godoc.org/github.com/disksing/iter#Sample), [Partition](https://godoc.org/github.com/disksing/iter#Partition).
+| Package | Purpose |
+|---|---|
+| `iter` | Iterator contracts and adapters for generated values, channels, and `io.Writer` |
+| `iter/algo` | Generic algorithms over iterator ranges |
+| `iter/slices` | Direct, type-inferred APIs for common slice algorithms |
+| `iter/lists` | Typed iterator adapters for `container/list` |
+| `iter/strs` | Byte iterators and string output helpers |
 
-- STL also includes some complicated algorithms that may take hours to make it correct. **Implementing it manually is impractical**. Such as [NthElement](https://godoc.org/github.com/disksing/iter#NthElement), [StablePartition](https://godoc.org/github.com/disksing/iter#StablePartition), [NextPermutation](https://godoc.org/github.com/disksing/iter#NextPermutation).
-
-- The implementation in the library contains some **imperceptible performance optimizations**. For instance, [MinmaxElement](https://godoc.org/github.com/disksing/iter#MinmaxElement) is done by taking two elements at a time. In this way, the overall number of comparisons is significantly reduced.
-
-There are alternative libraries have similar goals, such as [gostl](https://github.com/liyue201/gostl), [gods](https://github.com/emirpasic/gods) and [go-stp](https://github.com/itrabbit/go-stp). What makes `iter` unique is:
-
-- **Non-intrusive**. Instead of introducing new containers, `iter` tends to reuse existed containers in Go (slice, string, list.List, etc.) and use iterators to adapt them to algorithms.
-
-- **Full algorithms (>100)**. It includes almost all algorithms come before C++17. Check the [Full List](https://github.com/disksing/iter/wiki/Algorithms).
+The `slices` package is the simplest entry point for slice data. The `algo`
+package exposes the full iterator-based API for custom containers and mixed
+input/output sources.
 
 ## Examples
 
-> The examples are run with some function alias to make it simple. See [example_test.go](https://github.com/disksing/iter/blob/master/examples_test.go) for the detail.
-
-<table>
-<thead><tr><th colspan="2">Print a list.List</th></tr></thead>
-<tbody><td>
+### Sort, deduplicate, and search a slice
 
 ```go
-l := list.New()
-for i := 1; i <= 5; i++ {
-  l.PushBack(i)
+package main
+
+import (
+	"fmt"
+
+	iterslices "github.com/disksing/iter/v2/slices"
+)
+
+func main() {
+	values := []int{3, 2, 1, 4, 3, 2, 1}
+	iterslices.Sort(values)
+	values = iterslices.Unique(values)
+
+	fmt.Println(values)
+	fmt.Println(iterslices.BinarySearch(values, 3))
+	fmt.Println(iterslices.LowerBound(values, 3))
 }
-for e := l.Front(); e != nil; e = e.Next() {
-  fmt.Print(e.Value)
-  if e.Next() != nil {
-    fmt.Print("->")
-  }
+```
+
+Output:
+
+```text
+[1 2 3 4]
+true
+2
+```
+
+### Run an algorithm across different containers
+
+```go
+package main
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+
+	"github.com/disksing/iter/v2"
+	"github.com/disksing/iter/v2/algo"
+	iterlists "github.com/disksing/iter/v2/lists"
+)
+
+func main() {
+	src := list.New()
+	algo.GenerateN(iterlists.ListBackInserter[int](src), 5, iter.IotaGenerator(1))
+
+	var out bytes.Buffer
+	algo.Copy(
+		iterlists.Begin[int](src),
+		iterlists.End[int](src),
+		iter.IOWriter[int](&out, ", "),
+	)
+	fmt.Println(out.String())
 }
-// Output:
-// 1->2->3->4->5
 ```
 
-</td><td>
+Output:
+
+```text
+1, 2, 3, 4, 5
+```
+
+To collect values in a slice instead, use an appender:
 
 ```go
-l := list.New()
-GenerateN(ListBackInserter(l), 5, IotaGenerator(1))
-Copy(lBegin(l), lEnd(l), IOWriter(os.Stdout, "->"))
-// Output:
-// 1->2->3->4->5
+var dst []int
+algo.Copy(
+	iterlists.Begin[int](src),
+	iterlists.End[int](src),
+	iterslices.Appender(&dst),
+)
 ```
 
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">Reverse a string</th></tr></thead>
-<tbody><tr><td>
-
-```go
-s := "!dlrow olleH"
-var sb strings.Builder
-for i := len(s) - 1; i >= 0; i-- {
-  sb.WriteByte(s[i])
-}
-fmt.Println(sb.String())
-
-b := []byte(s)
-for i := len(s)/2 - 1; i >= 0; i-- {
-  j := len(s) - 1 - i
-  b[i], b[j] = b[j], b[i]
-}
-fmt.Println(string(b))
-// Output:
-// Hello world!
-// Hello world!
-```
-
-</td><td>
-
-```go
-s := "!dlrow olleH"
-fmt.Println(MakeString(StringRBegin(s), StringREnd(s)))
-
-b := []byte(s)
-Reverse(begin(b), end(b))
-fmt.Println(string(b))
-// Output:
-// Hello world!
-// Hello world!
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">In-place deduplicate (from <a href="https://github.com/golang/go/wiki/SliceTricks#in-place-deduplicate-comparable">SliceTricks</a>, with minor change)</th></tr></thead>
-<tbody><tr><td>
-
-```go
-in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
-sort.Ints(in)
-j := 0
-for i := 1; i < len(in); i++ {
-  if in[j] == in[i] {
-    continue
-  }
-  j++
-  in[j] = in[i]
-}
-in = in[:j+1]
-fmt.Println(in)
-// Output:
-// [1 2 3 4]
-```
-
-</td><td>
-
-```go
-in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
-Sort(begin(in), end(in))
-Erase(&in, Unique(begin(in), end(in)))
-fmt.Println(in)
-// Output:
-// [1 2 3 4]
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">Sum all integers received from a channel</th></tr></thead>
-<tbody><tr><td>
+### Read from a channel
 
 ```go
 ch := make(chan int)
 go func() {
-  for _, x := range rand.Perm(100) {
-    ch <- x + 1
-  }
-  close(ch)
+	algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
+	close(ch)
 }()
-var sum int
-for x := range ch {
-  sum += x
-}
-fmt.Println(sum)
-// Output:
-// 5050
+
+sum := algo.Accumulate(iter.ChanReader(ch), nil, 0)
+fmt.Println(sum) // 5050
 ```
 
-</td><td>
+More executable examples are in [`examples_test.go`](examples_test.go).
 
-```go
-ch := make(chan int)
-go func() {
-  CopyN(IotaReader(1), 100, ChanWriter(ch))
-  close(ch)
-}()
-fmt.Println(Accumulate(ChanReader(ch), ChanEOF, 0))
-// Output:
-// 5050
+## Iterator model
+
+Algorithms accept half-open ranges `[first, last)`. Iterator capabilities are
+expressed by generic interfaces:
+
+- `InputIter` reads and moves forward once.
+- `ForwardReader` supports multiple passes.
+- `BidiReadWriter` moves both directions and can modify values.
+- `RandomReadWriter` adds constant-time distance and indexed movement.
+- `OutputIter` writes values to a destination.
+
+Concrete iterator types are exported so callers can use them in their own
+fields and signatures:
+
+- `slices.Iterator[T]`
+- `lists.Iterator[T]`
+- `strs.Iterator`
+- `iter.IotaIterator[T]`, `iter.RepeatIterator[T]`
+- `iter.ChannelReader[T]`, `iter.ChannelWriter[T]`
+- `iter.OutputWriter[T]`
+
+Default algorithms use operators when their type constraint permits it.
+Variants ending in `By` accept a predicate, equality function, or ordering
+function for custom types.
+
+## Standard-library iterators
+
+Go's standard `iter.Seq` is a good fit for read-only and lazy sequences, but it
+does not directly model writable, bidirectional, or random-access positions.
+This project keeps cursor-style algorithms for operations such as
+`NthElement`, heap manipulation, in-place partitioning, and permutations.
+Interoperability with standard `iter.Seq` is planned separately from the
+current API hardening work.
+
+## Development
+
+```sh
+go mod verify
+go vet ./...
+go test -race ./...
+go test ./algo -run=^$ -fuzz=^FuzzSort$ -fuzztime=10s
+go test ./algo -run=^$ -fuzz=^FuzzNthElement$ -fuzztime=10s
 ```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">Remove consecutive spaces in a string</th></tr></thead>
-<tbody><tr><td>
-
-```go
-str := "  a  quick   brown  fox  "
-var sb strings.Builder
-var prevIsSpace bool
-for i := 0; i < len(str); i++ {
-  if str[i] != ' ' || !prevIsSpace {
-    sb.WriteByte(str[i])
-  }
-  prevIsSpace = str[i] == ' '
-}
-fmt.Println(sb.String())
-// Output:
-// a quick brown fox
-```
-
-</td><td>
-
-```go
-str := "  a  quick   brown  fox  "
-var sb StringBuilderInserter
-UniqueCopyIf(sBegin(str), sEnd(str), &sb,
-  func(x, y Any) bool { return x.(byte) == ' ' && y.(byte) == ' ' })
-fmt.Println(sb.String())
-// Output:
-// a quick brown fox
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">Collect N maximum elements from a channel</th></tr></thead>
-<tbody><tr><td>
-
-```go
-// Need to manually mantain a min-heap.
-```
-
-</td><td>
-
-```go
-top := make([]int, 5)
-PartialSortCopyBy(ChanReader(ch), ChanEOF, begin(top), end(top),
-  func(x, y Any) bool { return x.(int) > y.(int) })
-Copy(begin(top), end(top), IOWriter(os.Stdout, ", "))
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">Print all permutations of ["a", "b", "c"]</th></tr></thead>
-<tbody><tr><td>
-
-```go
-// Usually requires some sort of recursion
-```
-
-</td><td>
-
-```go
-s := []string{"a", "b", "c"}
-for ok := true; ok; ok = NextPermutation(begin(s), end(s)) {
-  fmt.Println(s)
-}
-// Output:
-// [a b c]
-// [a c b]
-// [b a c]
-// [b c a]
-// [c a b]
-// [c b a]
-```
-
-</td></tr></tbody>
-</table>
-
-## Thanks
-
-- [cppreference.com](https://en.cppreference.com/)
-- [LLVM libc++](https://libcxx.llvm.org/)
 
 ## License
 
-BSD 3-Clause
+BSD 3-Clause. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,175 +1,258 @@
 # iter
 
-Generic Go implementations of the C++ standard algorithms.
+**Note: The generic v2 API is still under development and has not been released. It requires Go 1.26 or later. For the previous version, please check the [`v1` branch](https://github.com/disksing/iter/tree/v1).**
 
-`iter` provides type-safe iterator contracts, more than 100 reusable
-algorithms, and convenient adapters for slices, strings, channels, and
-`container/list`.
+Go implementation of C++ STL iterators and algorithms.
 
-> **Development status:** the generic v2 API is being prepared and has not been
-> released. Use the [`v1` branch](https://github.com/disksing/iter/tree/v1) for
-> the previous non-generic version.
+Less hand-written loops, more expressive code.
 
-[简体中文](README_ZH.md)
+README translations: [简体中文](README_ZH.md)
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/disksing/iter/v2.svg)](https://pkg.go.dev/github.com/disksing/iter/v2)
 [![CI](https://github.com/disksing/iter/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/disksing/iter/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/disksing/iter/branch/master/graph/badge.svg)](https://codecov.io/gh/disksing/iter)
+[![Go Report Card](https://goreportcard.com/badge/github.com/disksing/iter/v2)](https://goreportcard.com/report/github.com/disksing/iter/v2)
 
-## Requirements
+## Motivation
 
-Go 1.26 or later.
+Go now has generics, and we deserve to have reusable general algorithms. `iter` helps improve Go code in several ways:
 
-## Packages
+- Some simple loops are unlikely to be wrong or inefficient, but calling an algorithm instead will **make the code more concise and easier to comprehend**. Such as [AllOf](https://pkg.go.dev/github.com/disksing/iter/v2/algo#AllOf), [FindIf](https://pkg.go.dev/github.com/disksing/iter/v2/algo#FindIf), [Accumulate](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Accumulate).
 
-| Package | Purpose |
-|---|---|
-| `iter` | Iterator contracts and adapters for generated values, channels, and `io.Writer` |
-| `iter/algo` | Generic algorithms over iterator ranges |
-| `iter/slices` | Direct, type-inferred APIs for common slice algorithms |
-| `iter/lists` | Typed iterator adapters for `container/list` |
-| `iter/strs` | Byte iterators and string output helpers |
+- Some algorithms are not complicated, but it is not easy to write them correctly. **Reusing code makes them easier to reason for correctness**. Such as [Shuffle](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Shuffle), [Sample](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Sample), [Partition](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Partition).
 
-The `slices` package is the simplest entry point for slice data. The `algo`
-package exposes the full iterator-based API for custom containers and mixed
-input/output sources.
+- STL also includes some complicated algorithms that may take hours to make it correct. **Implementing it manually is impractical**. Such as [NthElement](https://pkg.go.dev/github.com/disksing/iter/v2/algo#NthElement), [StablePartition](https://pkg.go.dev/github.com/disksing/iter/v2/algo#StablePartition), [NextPermutation](https://pkg.go.dev/github.com/disksing/iter/v2/algo#NextPermutation).
+
+- The implementation in the library contains some **imperceptible performance optimizations**. For instance, [MinmaxElement](https://pkg.go.dev/github.com/disksing/iter/v2/algo#MinmaxElement) is done by taking two elements at a time. In this way, the overall number of comparisons is significantly reduced.
+
+There are alternative libraries have similar goals, such as [gostl](https://github.com/liyue201/gostl), [gods](https://github.com/emirpasic/gods) and [go-stp](https://github.com/itrabbit/go-stp). What makes `iter` unique is:
+
+- **Non-intrusive**. Instead of introducing new containers, `iter` tends to reuse existed containers in Go (slice, string, list.List, etc.) and use iterators to adapt them to algorithms.
+
+- **Full algorithms (>100)**. It includes almost all algorithms come before C++17. Check the [Full List](https://github.com/disksing/iter/wiki/Algorithms).
 
 ## Examples
 
-### Sort, deduplicate, and search a slice
+> The examples keep package qualifiers so the generic v2 API is explicit. See [examples_test.go](examples_test.go) for complete, executable examples.
+
+<table>
+<thead><tr><th colspan="2">Print a list.List</th></tr></thead>
+<tbody><tr><td>
 
 ```go
-package main
-
-import (
-	"fmt"
-
-	iterslices "github.com/disksing/iter/v2/slices"
-)
-
-func main() {
-	values := []int{3, 2, 1, 4, 3, 2, 1}
-	iterslices.Sort(values)
-	values = iterslices.Unique(values)
-
-	fmt.Println(values)
-	fmt.Println(iterslices.BinarySearch(values, 3))
-	fmt.Println(iterslices.LowerBound(values, 3))
+l := list.New()
+for i := 1; i <= 5; i++ {
+  l.PushBack(i)
 }
-```
-
-Output:
-
-```text
-[1 2 3 4]
-true
-2
-```
-
-### Run an algorithm across different containers
-
-```go
-package main
-
-import (
-	"bytes"
-	"container/list"
-	"fmt"
-
-	"github.com/disksing/iter/v2"
-	"github.com/disksing/iter/v2/algo"
-	iterlists "github.com/disksing/iter/v2/lists"
-)
-
-func main() {
-	src := list.New()
-	algo.GenerateN(iterlists.ListBackInserter[int](src), 5, iter.IotaGenerator(1))
-
-	var out bytes.Buffer
-	algo.Copy(
-		iterlists.Begin[int](src),
-		iterlists.End[int](src),
-		iter.IOWriter[int](&out, ", "),
-	)
-	fmt.Println(out.String())
+for e := l.Front(); e != nil; e = e.Next() {
+  fmt.Print(e.Value)
+  if e.Next() != nil {
+    fmt.Print("->")
+  }
 }
+// Output:
+// 1->2->3->4->5
 ```
 
-Output:
-
-```text
-1, 2, 3, 4, 5
-```
-
-To collect values in a slice instead, use an appender:
+</td><td>
 
 ```go
-var dst []int
-algo.Copy(
-	iterlists.Begin[int](src),
-	iterlists.End[int](src),
-	iterslices.Appender(&dst),
-)
+l := list.New()
+algo.GenerateN(lists.ListBackInserter[int](l), 5, iter.IotaGenerator(1))
+algo.Copy(lists.Begin[int](l), lists.End[int](l), iter.IOWriter[int](os.Stdout, "->"))
+// Output:
+// 1->2->3->4->5
 ```
 
-### Read from a channel
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">Reverse a string</th></tr></thead>
+<tbody><tr><td>
+
+```go
+s := "!dlrow olleH"
+var sb strings.Builder
+for i := len(s) - 1; i >= 0; i-- {
+  sb.WriteByte(s[i])
+}
+fmt.Println(sb.String())
+
+b := []byte(s)
+for i := len(s)/2 - 1; i >= 0; i-- {
+  j := len(s) - 1 - i
+  b[i], b[j] = b[j], b[i]
+}
+fmt.Println(string(b))
+// Output:
+// Hello world!
+// Hello world!
+```
+
+</td><td>
+
+```go
+s := "!dlrow olleH"
+fmt.Println(strs.MakeString(strs.RBegin(s), strs.REnd(s)))
+
+b := []byte(s)
+iterslices.Reverse(b)
+fmt.Println(string(b))
+// Output:
+// Hello world!
+// Hello world!
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">In-place deduplicate (from <a href="https://go.dev/wiki/SliceTricks#in-place-deduplicate-comparable">SliceTricks</a>, with minor change)</th></tr></thead>
+<tbody><tr><td>
+
+```go
+in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
+sort.Ints(in)
+j := 0
+for i := 1; i < len(in); i++ {
+  if in[j] == in[i] {
+    continue
+  }
+  j++
+  in[j] = in[i]
+}
+in = in[:j+1]
+fmt.Println(in)
+// Output:
+// [1 2 3 4]
+```
+
+</td><td>
+
+```go
+in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
+iterslices.Sort(in)
+in = iterslices.Unique(in)
+fmt.Println(in)
+// Output:
+// [1 2 3 4]
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">Sum all integers received from a channel</th></tr></thead>
+<tbody><tr><td>
 
 ```go
 ch := make(chan int)
 go func() {
-	algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
-	close(ch)
+  for _, x := range rand.Perm(100) {
+    ch <- x + 1
+  }
+  close(ch)
 }()
-
-sum := algo.Accumulate(iter.ChanReader(ch), nil, 0)
-fmt.Println(sum) // 5050
+var sum int
+for x := range ch {
+  sum += x
+}
+fmt.Println(sum)
+// Output:
+// 5050
 ```
 
-More executable examples are in [`examples_test.go`](examples_test.go).
+</td><td>
 
-## Iterator model
-
-Algorithms accept half-open ranges `[first, last)`. Iterator capabilities are
-expressed by generic interfaces:
-
-- `InputIter` reads and moves forward once.
-- `ForwardReader` supports multiple passes.
-- `BidiReadWriter` moves both directions and can modify values.
-- `RandomReadWriter` adds constant-time distance and indexed movement.
-- `OutputIter` writes values to a destination.
-
-Concrete iterator types are exported so callers can use them in their own
-fields and signatures:
-
-- `slices.Iterator[T]`
-- `lists.Iterator[T]`
-- `strs.Iterator`
-- `iter.IotaIterator[T]`, `iter.RepeatIterator[T]`
-- `iter.ChannelReader[T]`, `iter.ChannelWriter[T]`
-- `iter.OutputWriter[T]`
-
-Default algorithms use operators when their type constraint permits it.
-Variants ending in `By` accept a predicate, equality function, or ordering
-function for custom types.
-
-## Standard-library iterators
-
-Go's standard `iter.Seq` is a good fit for read-only and lazy sequences, but it
-does not directly model writable, bidirectional, or random-access positions.
-This project keeps cursor-style algorithms for operations such as
-`NthElement`, heap manipulation, in-place partitioning, and permutations.
-Interoperability with standard `iter.Seq` is planned separately from the
-current API hardening work.
-
-## Development
-
-```sh
-go mod verify
-go vet ./...
-go test -race ./...
-go test ./algo -run=^$ -fuzz=^FuzzSort$ -fuzztime=10s
-go test ./algo -run=^$ -fuzz=^FuzzNthElement$ -fuzztime=10s
+```go
+ch := make(chan int)
+go func() {
+  algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
+  close(ch)
+}()
+fmt.Println(algo.Accumulate(iter.ChanReader(ch), nil, 0))
+// Output:
+// 5050
 ```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">Remove consecutive spaces in a string</th></tr></thead>
+<tbody><tr><td>
+
+```go
+str := "  a  quick   brown  fox  "
+var sb strings.Builder
+var prevIsSpace bool
+for i := 0; i < len(str); i++ {
+  if str[i] != ' ' || !prevIsSpace {
+    sb.WriteByte(str[i])
+  }
+  prevIsSpace = str[i] == ' '
+}
+fmt.Println(sb.String())
+// Output:
+// a quick brown fox
+```
+
+</td><td>
+
+```go
+str := "  a  quick   brown  fox  "
+var sb strs.StringBuilderInserter[byte]
+algo.UniqueCopyIf(strs.Begin(str), strs.End(str), &sb,
+  func(x, y byte) bool { return x == ' ' && y == ' ' })
+fmt.Println(sb.String())
+// Output:
+// a quick brown fox
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">Collect N maximum elements from a channel</th></tr></thead>
+<tbody><tr><td>
+
+```go
+// Need to manually maintain a min-heap.
+```
+
+</td><td>
+
+```go
+top := make([]int, 5)
+algo.PartialSortCopyBy(iter.ChanReader(ch), nil, iterslices.Begin(top), iterslices.End(top),
+  func(x, y int) bool { return x > y })
+algo.Copy(iterslices.Begin(top), iterslices.End(top), iter.IOWriter[int](os.Stdout, ", "))
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">Print all permutations of ["a", "b", "c"]</th></tr></thead>
+<tbody><tr><td>
+
+```go
+// Usually requires some sort of recursion.
+```
+
+</td><td>
+
+```go
+s := []string{"a", "b", "c"}
+for ok := true; ok; ok = iterslices.NextPermutation(s) {
+  fmt.Println(s)
+}
+// Output:
+// [a b c]
+// [a c b]
+// [b a c]
+// [b c a]
+// [c a b]
+// [c b a]
+```
+
+</td></tr></tbody>
+</table>
+
+## Thanks
+
+- [cppreference.com](https://en.cppreference.com/)
+- [LLVM libc++](https://libcxx.llvm.org/)
 
 ## License
 
-BSD 3-Clause. See [LICENSE](LICENSE).
+BSD 3-Clause

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,136 +1,256 @@
 # iter
 
-C++ 标准算法的 Go 泛型实现。
+**注意：泛型 v2 API 仍在开发中，尚未发布，并要求 Go 1.26 或更高版本。如需此前可用的版本，请查看 [`v1` 分支](https://github.com/disksing/iter/tree/v1)。**
 
-`iter` 提供类型安全的迭代器约束、100 多个可复用算法，以及 slice、
-string、channel 和 `container/list` 的便捷适配器。
+C++ STL 迭代器和算法库的 Go 语言实现。
 
-> **开发状态：** 泛型 v2 API 正在整理，尚未发布。此前可用的非泛型版本
-> 位于 [`v1` 分支](https://github.com/disksing/iter/tree/v1)。
+更少的手写循环，更多富有表达力的代码。
 
-[English](README.md)
-
+[![Go Reference](https://pkg.go.dev/badge/github.com/disksing/iter/v2.svg)](https://pkg.go.dev/github.com/disksing/iter/v2)
 [![CI](https://github.com/disksing/iter/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/disksing/iter/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/disksing/iter/branch/master/graph/badge.svg)](https://codecov.io/gh/disksing/iter)
+[![Go Report Card](https://goreportcard.com/badge/github.com/disksing/iter/v2)](https://goreportcard.com/report/github.com/disksing/iter/v2)
 
-## 环境要求
+## 动机
 
-Go 1.26 或更高版本。
+Go 现在已经支持泛型，我们值得拥有可复用的通用算法。`iter` 可以在以下方面帮助改善代码：
 
-## 包结构
+- 一些简单的循环逻辑不太可能写错或者低效，但使用算法调用将**使得代码更简洁和易于理解**。例如 [AllOf](https://pkg.go.dev/github.com/disksing/iter/v2/algo#AllOf)，[FindIf](https://pkg.go.dev/github.com/disksing/iter/v2/algo#FindIf)，[Accumulate](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Accumulate)。
 
-| 包 | 用途 |
-|---|---|
-| `iter` | 迭代器约束，以及生成值、channel、`io.Writer` 等适配器 |
-| `iter/algo` | 面向迭代器区间的完整泛型算法 |
-| `iter/slices` | 常用 slice 算法，可直接依赖类型推断调用 |
-| `iter/lists` | `container/list` 的类型化迭代器适配器 |
-| `iter/strs` | 字节级 string 迭代器和字符串输出工具 |
+- 一些算法并不是很复杂，但不太容易写对。使用算法库**让代码“一眼看上去就是对的”**。例如 [Shuffle](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Shuffle)，[Sample](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Sample)，[Partition](https://pkg.go.dev/github.com/disksing/iter/v2/algo#Partition)。
 
-处理 slice 时优先使用 `slices` 包；需要自定义容器、跨容器复制或完整算法
-集合时使用 `algo` 包。
+- STL 还包含一些复杂算法，可能需要数小时才能搞对。**手动实现它们并不现实**。例如 [NthElement](https://pkg.go.dev/github.com/disksing/iter/v2/algo#NthElement)，[StablePartition](https://pkg.go.dev/github.com/disksing/iter/v2/algo#StablePartition)，[NextPermutation](https://pkg.go.dev/github.com/disksing/iter/v2/algo#NextPermutation)。
+
+- STL 的实现还有一些**鲜为人知的性能优化**。比如，[MinmaxElement](https://pkg.go.dev/github.com/disksing/iter/v2/algo#MinmaxElement) 被实现为每次取两个元素进行比较，这样做可以大幅减少整体比较次数。
+
+有一些开源项目在做类似的事情，比如 [gostl](https://github.com/liyue201/gostl)，[gods](https://github.com/emirpasic/gods) 和 [go-stp](https://github.com/itrabbit/go-stp)。`iter` 的独特之处在于：
+
+- **非侵入性**。`iter` 避免重复造轮子，尽可能地复用 Go 里已有的容器（slice，string，list.List 等），使用迭代器将它们适配给算法库。
+
+- **完整的算法库（>100）**。它实现了几乎所有 C++17 之前的算法。在[这里](https://github.com/disksing/iter/wiki/Algorithms)可以查看完整列表。
 
 ## 示例
 
-### 排序、去重和查找
+> 示例保留包名前缀，以明确对应的泛型 v2 API。完整且可执行的示例见 [examples_test.go](examples_test.go)。
+
+<table>
+<thead><tr><th colspan="2">控制台输出 list.List</th></tr></thead>
+<tbody><tr><td>
 
 ```go
-package main
-
-import (
-	"fmt"
-
-	iterslices "github.com/disksing/iter/v2/slices"
-)
-
-func main() {
-	values := []int{3, 2, 1, 4, 3, 2, 1}
-	iterslices.Sort(values)
-	values = iterslices.Unique(values)
-
-	fmt.Println(values)
-	fmt.Println(iterslices.BinarySearch(values, 3))
-	fmt.Println(iterslices.LowerBound(values, 3))
+l := list.New()
+for i := 1; i <= 5; i++ {
+  l.PushBack(i)
 }
+for e := l.Front(); e != nil; e = e.Next() {
+  fmt.Print(e.Value)
+  if e.Next() != nil {
+    fmt.Print("->")
+  }
+}
+// Output:
+// 1->2->3->4->5
 ```
 
-输出：
-
-```text
-[1 2 3 4]
-true
-2
-```
-
-### 在不同容器之间运行算法
+</td><td>
 
 ```go
-src := list.New()
-algo.GenerateN(iterlists.ListBackInserter[int](src), 5, iter.IotaGenerator(1))
-
-var dst []int
-algo.Copy(
-	iterlists.Begin[int](src),
-	iterlists.End[int](src),
-	iterslices.Appender(&dst),
-)
-fmt.Println(dst) // [1 2 3 4 5]
+l := list.New()
+algo.GenerateN(lists.ListBackInserter[int](l), 5, iter.IotaGenerator(1))
+algo.Copy(lists.Begin[int](l), lists.End[int](l), iter.IOWriter[int](os.Stdout, "->"))
+// Output:
+// 1->2->3->4->5
 ```
 
-### 从 channel 读取
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">反转 string</th></tr></thead>
+<tbody><tr><td>
+
+```go
+s := "!dlrow olleH"
+var sb strings.Builder
+for i := len(s) - 1; i >= 0; i-- {
+  sb.WriteByte(s[i])
+}
+fmt.Println(sb.String())
+
+b := []byte(s)
+for i := len(s)/2 - 1; i >= 0; i-- {
+  j := len(s) - 1 - i
+  b[i], b[j] = b[j], b[i]
+}
+fmt.Println(string(b))
+// Output:
+// Hello world!
+// Hello world!
+```
+
+</td><td>
+
+```go
+s := "!dlrow olleH"
+fmt.Println(strs.MakeString(strs.RBegin(s), strs.REnd(s)))
+
+b := []byte(s)
+iterslices.Reverse(b)
+fmt.Println(string(b))
+// Output:
+// Hello world!
+// Hello world!
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">去重（来自 <a href="https://go.dev/wiki/SliceTricks#in-place-deduplicate-comparable">SliceTricks</a>，略微调整）</th></tr></thead>
+<tbody><tr><td>
+
+```go
+in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
+sort.Ints(in)
+j := 0
+for i := 1; i < len(in); i++ {
+  if in[j] == in[i] {
+    continue
+  }
+  j++
+  in[j] = in[i]
+}
+in = in[:j+1]
+fmt.Println(in)
+// Output:
+// [1 2 3 4]
+```
+
+</td><td>
+
+```go
+in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
+iterslices.Sort(in)
+in = iterslices.Unique(in)
+fmt.Println(in)
+// Output:
+// [1 2 3 4]
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">对 channel 中的所有整数求和</th></tr></thead>
+<tbody><tr><td>
 
 ```go
 ch := make(chan int)
 go func() {
-	algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
-	close(ch)
+  for _, x := range rand.Perm(100) {
+    ch <- x + 1
+  }
+  close(ch)
 }()
-
-sum := algo.Accumulate(iter.ChanReader(ch), nil, 0)
-fmt.Println(sum) // 5050
+var sum int
+for x := range ch {
+  sum += x
+}
+fmt.Println(sum)
+// Output:
+// 5050
 ```
 
-更多可执行示例见 [`examples_test.go`](examples_test.go)。
+</td><td>
 
-## 迭代器模型
-
-算法使用左闭右开区间 `[first, last)`。泛型接口表达不同的迭代能力：
-
-- `InputIter`：单次向前读取；
-- `ForwardReader`：允许多次遍历；
-- `BidiReadWriter`：可双向移动并修改值；
-- `RandomReadWriter`：额外支持常数时间的距离和按偏移移动；
-- `OutputIter`：向目标写值。
-
-具体类型均已导出，调用者可以在自己的字段和函数签名中使用：
-
-- `slices.Iterator[T]`
-- `lists.Iterator[T]`
-- `strs.Iterator`
-- `iter.IotaIterator[T]`、`iter.RepeatIterator[T]`
-- `iter.ChannelReader[T]`、`iter.ChannelWriter[T]`
-- `iter.OutputWriter[T]`
-
-默认算法在类型约束允许时使用运算符；以 `By` 结尾的变体接收自定义 predicate、
-相等比较器或顺序比较器。
-
-## 与标准库 iter 的关系
-
-标准库 `iter.Seq` 很适合只读和惰性序列，但不能直接表达可写、双向或随机访问
-的位置。`NthElement`、heap、原地 partition、permutation 等正是本项目保留
-cursor 模型的原因。与标准 `iter.Seq` 的互操作会作为后续工作单独设计，不与
-当前 API 加固混在一起。
-
-## 开发验证
-
-```sh
-go mod verify
-go vet ./...
-go test -race ./...
-go test ./algo -run=^$ -fuzz=^FuzzSort$ -fuzztime=10s
-go test ./algo -run=^$ -fuzz=^FuzzNthElement$ -fuzztime=10s
+```go
+ch := make(chan int)
+go func() {
+  algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
+  close(ch)
+}()
+fmt.Println(algo.Accumulate(iter.ChanReader(ch), nil, 0))
+// Output:
+// 5050
 ```
 
-## 许可证
+</td></tr></tbody>
 
-BSD 3-Clause，详见 [LICENSE](LICENSE)。
+<thead><tr><th colspan="2">删除字符串中的连续空格</th></tr></thead>
+<tbody><tr><td>
+
+```go
+str := "  a  quick   brown  fox  "
+var sb strings.Builder
+var prevIsSpace bool
+for i := 0; i < len(str); i++ {
+  if str[i] != ' ' || !prevIsSpace {
+    sb.WriteByte(str[i])
+  }
+  prevIsSpace = str[i] == ' '
+}
+fmt.Println(sb.String())
+// Output:
+// a quick brown fox
+```
+
+</td><td>
+
+```go
+str := "  a  quick   brown  fox  "
+var sb strs.StringBuilderInserter[byte]
+algo.UniqueCopyIf(strs.Begin(str), strs.End(str), &sb,
+  func(x, y byte) bool { return x == ' ' && y == ' ' })
+fmt.Println(sb.String())
+// Output:
+// a quick brown fox
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">收集 channel 中最大的 N 个整数</th></tr></thead>
+<tbody><tr><td>
+
+```go
+// 需要手动维护小顶堆。
+```
+
+</td><td>
+
+```go
+top := make([]int, 5)
+algo.PartialSortCopyBy(iter.ChanReader(ch), nil, iterslices.Begin(top), iterslices.End(top),
+  func(x, y int) bool { return x > y })
+algo.Copy(iterslices.Begin(top), iterslices.End(top), iter.IOWriter[int](os.Stdout, ", "))
+```
+
+</td></tr></tbody>
+
+<thead><tr><th colspan="2">输出 ["a", "b", "c"] 的所有排列</th></tr></thead>
+<tbody><tr><td>
+
+```go
+// 通常需要引入递归来完成。
+```
+
+</td><td>
+
+```go
+s := []string{"a", "b", "c"}
+for ok := true; ok; ok = iterslices.NextPermutation(s) {
+  fmt.Println(s)
+}
+// Output:
+// [a b c]
+// [a c b]
+// [b a c]
+// [b c a]
+// [c a b]
+// [c b a]
+```
+
+</td></tr></tbody>
+</table>
+
+## 致谢
+
+- [cppreference.com](https://en.cppreference.com/)
+- [LLVM libc++](https://libcxx.llvm.org/)
+
+## 开源许可证
+
+BSD 3-Clause

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -1,256 +1,136 @@
 # iter
 
-**注意：我正在努力使其兼容 Go1.18 支持的泛型。如需旧版本请查看 `v1` 分支。**
+C++ 标准算法的 Go 泛型实现。
 
-C++ STL 迭代器和算法库的 Go 语言实现。
+`iter` 提供类型安全的迭代器约束、100 多个可复用算法，以及 slice、
+string、channel 和 `container/list` 的便捷适配器。
 
-更少的手写循环，更多富有表达力的代码。
+> **开发状态：** 泛型 v2 API 正在整理，尚未发布。此前可用的非泛型版本
+> 位于 [`v1` 分支](https://github.com/disksing/iter/tree/v1)。
 
-[![GoDoc](https://godoc.org/github.com/disksing/iter?status.svg)](https://godoc.org/github.com/disksing/iter)
-[![Build Status](https://travis-ci.com/disksing/iter.svg?branch=master)](https://travis-ci.com/disksing/iter)
+[English](README.md)
+
+[![CI](https://github.com/disksing/iter/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/disksing/iter/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/disksing/iter/branch/master/graph/badge.svg)](https://codecov.io/gh/disksing/iter)
-[![Go Report Card](https://goreportcard.com/badge/github.com/disksing/iter)](https://goreportcard.com/report/github.com/disksing/iter)
 
-## 动机
+## 环境要求
 
-虽然 Go 不支持泛型，我们值得拥有可复用的通用算法。`iter` 可以在以下方面帮助改善代码：
+Go 1.26 或更高版本。
 
-- 一些简单的循环逻辑不太可能写错或者低效，但使用算法调用将**使得代码更简洁和易于理解**。例如 [AllOf](https://godoc.org/github.com/disksing/iter#AllOf)，[FindIf](https://godoc.org/github.com/disksing/iter#FindIf)，[Accumulate](https://godoc.org/github.com/disksing/iter#Accumulate)。
+## 包结构
 
-- 一些算法并不是很复杂，但不太容易写对。使用算法库**让代码“一眼看上去就是对的”**。例如 [Shuffle](https://godoc.org/github.com/disksing/iter#Shuffle)，[Sample](https://godoc.org/github.com/disksing/iter#Sample)，[Partition](https://godoc.org/github.com/disksing/iter#Partition)。
+| 包 | 用途 |
+|---|---|
+| `iter` | 迭代器约束，以及生成值、channel、`io.Writer` 等适配器 |
+| `iter/algo` | 面向迭代器区间的完整泛型算法 |
+| `iter/slices` | 常用 slice 算法，可直接依赖类型推断调用 |
+| `iter/lists` | `container/list` 的类型化迭代器适配器 |
+| `iter/strs` | 字节级 string 迭代器和字符串输出工具 |
 
-- STL 还包含一些复杂算法，可能需要数小时才能搞对。**手动实现它们并不现实**。例如 [NthElement](https://godoc.org/github.com/disksing/iter#NthElement)，[StablePartition](https://godoc.org/github.com/disksing/iter#StablePartition)，[NextPermutation](https://godoc.org/github.com/disksing/iter#NextPermutation)。
-
-- STL 的实现还有一些**鲜为人知的性能优化**。比如，[MinmaxElement](https://godoc.org/github.com/disksing/iter#MinmaxElement) 被实现为每次取两个元素进行比较，这样做可以大幅减少整体比较次数。
-
-有一些开源项目在做类似的事情，比如 [gostl](https://github.com/liyue201/gostl)，[gods](https://github.com/emirpasic/gods) 和 [go-stp](https://github.com/itrabbit/go-stp)。`iter` 的独特之处在于：
-
-- **非侵入性**。`iter` 避免重复造轮子，尽可能地复用 Go 里已有的容器（slice，string，list.List 等），使用迭代器将它们适配给算法库。
-
-- **完整的算法库（>100）**。它实现了几乎所有 C++17 之前的算法。在[这里](https://github.com/disksing/iter/wiki/Algorithms)可以查看完整列表。
+处理 slice 时优先使用 `slices` 包；需要自定义容器、跨容器复制或完整算法
+集合时使用 `algo` 包。
 
 ## 示例
 
-> 这些示例给一些函数定义了别名来使代码更美观，详情见 [example_test.go](https://github.com/disksing/iter/blob/master/examples_test.go)。
-
-<table>
-<thead><tr><th colspan="2">控制台输出 list.List</th></tr></thead>
-<tbody><td>
+### 排序、去重和查找
 
 ```go
-l := list.New()
-for i := 1; i <= 5; i++ {
-  l.PushBack(i)
+package main
+
+import (
+	"fmt"
+
+	iterslices "github.com/disksing/iter/v2/slices"
+)
+
+func main() {
+	values := []int{3, 2, 1, 4, 3, 2, 1}
+	iterslices.Sort(values)
+	values = iterslices.Unique(values)
+
+	fmt.Println(values)
+	fmt.Println(iterslices.BinarySearch(values, 3))
+	fmt.Println(iterslices.LowerBound(values, 3))
 }
-for e := l.Front(); e != nil; e = e.Next() {
-  fmt.Print(e.Value)
-  if e.Next() != nil {
-    fmt.Print("->")
-  }
-}
-// Output:
-// 1->2->3->4->5
 ```
 
-</td><td>
+输出：
+
+```text
+[1 2 3 4]
+true
+2
+```
+
+### 在不同容器之间运行算法
 
 ```go
-l := list.New()
-GenerateN(ListBackInserter(l), 5, IotaGenerator(1))
-Copy(lBegin(l), lEnd(l), IOWriter(os.Stdout, "->"))
-// Output:
-// 1->2->3->4->5
+src := list.New()
+algo.GenerateN(iterlists.ListBackInserter[int](src), 5, iter.IotaGenerator(1))
+
+var dst []int
+algo.Copy(
+	iterlists.Begin[int](src),
+	iterlists.End[int](src),
+	iterslices.Appender(&dst),
+)
+fmt.Println(dst) // [1 2 3 4 5]
 ```
 
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">反转 string</th></tr></thead>
-<tbody><tr><td>
-
-```go
-s := "!dlrow olleH"
-var sb strings.Builder
-for i := len(s) - 1; i >= 0; i-- {
-  sb.WriteByte(s[i])
-}
-fmt.Println(sb.String())
-
-b := []byte(s)
-for i := len(s)/2 - 1; i >= 0; i-- {
-  j := len(s) - 1 - i
-  b[i], b[j] = b[j], b[i]
-}
-fmt.Println(string(b))
-// Output:
-// Hello world!
-// Hello world!
-```
-
-</td><td>
-
-```go
-s := "!dlrow olleH"
-fmt.Println(MakeString(StringRBegin(s), StringREnd(s)))
-
-b := []byte(s)
-Reverse(begin(b), end(b))
-fmt.Println(string(b))
-// Output:
-// Hello world!
-// Hello world!
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">去重（来自 <a href="https://github.com/golang/go/wiki/SliceTricks#in-place-deduplicate-comparable">SliceTricks</a>，略微调整）</th></tr></thead>
-<tbody><tr><td>
-
-```go
-in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
-sort.Ints(in)
-j := 0
-for i := 1; i < len(in); i++ {
-  if in[j] == in[i] {
-    continue
-  }
-  j++
-  in[j] = in[i]
-}
-in = in[:j+1]
-fmt.Println(in)
-// Output:
-// [1 2 3 4]
-```
-
-</td><td>
-
-```go
-in := []int{3, 2, 1, 4, 3, 2, 1, 4, 1}
-Sort(begin(in), end(in))
-Erase(&in, Unique(begin(in), end(in)))
-fmt.Println(in)
-// Output:
-// [1 2 3 4]
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">对 channel 中的所有整数求和</th></tr></thead>
-<tbody><tr><td>
+### 从 channel 读取
 
 ```go
 ch := make(chan int)
 go func() {
-  for _, x := range rand.Perm(100) {
-    ch <- x + 1
-  }
-  close(ch)
+	algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
+	close(ch)
 }()
-var sum int
-for x := range ch {
-  sum += x
-}
-fmt.Println(sum)
-// Output:
-// 5050
+
+sum := algo.Accumulate(iter.ChanReader(ch), nil, 0)
+fmt.Println(sum) // 5050
 ```
 
-</td><td>
+更多可执行示例见 [`examples_test.go`](examples_test.go)。
 
-```go
-ch := make(chan int)
-go func() {
-  CopyN(IotaReader(1), 100, ChanWriter(ch))
-  close(ch)
-}()
-fmt.Println(Accumulate(ChanReader(ch), ChanEOF, 0))
-// Output:
-// 5050
+## 迭代器模型
+
+算法使用左闭右开区间 `[first, last)`。泛型接口表达不同的迭代能力：
+
+- `InputIter`：单次向前读取；
+- `ForwardReader`：允许多次遍历；
+- `BidiReadWriter`：可双向移动并修改值；
+- `RandomReadWriter`：额外支持常数时间的距离和按偏移移动；
+- `OutputIter`：向目标写值。
+
+具体类型均已导出，调用者可以在自己的字段和函数签名中使用：
+
+- `slices.Iterator[T]`
+- `lists.Iterator[T]`
+- `strs.Iterator`
+- `iter.IotaIterator[T]`、`iter.RepeatIterator[T]`
+- `iter.ChannelReader[T]`、`iter.ChannelWriter[T]`
+- `iter.OutputWriter[T]`
+
+默认算法在类型约束允许时使用运算符；以 `By` 结尾的变体接收自定义 predicate、
+相等比较器或顺序比较器。
+
+## 与标准库 iter 的关系
+
+标准库 `iter.Seq` 很适合只读和惰性序列，但不能直接表达可写、双向或随机访问
+的位置。`NthElement`、heap、原地 partition、permutation 等正是本项目保留
+cursor 模型的原因。与标准 `iter.Seq` 的互操作会作为后续工作单独设计，不与
+当前 API 加固混在一起。
+
+## 开发验证
+
+```sh
+go mod verify
+go vet ./...
+go test -race ./...
+go test ./algo -run=^$ -fuzz=^FuzzSort$ -fuzztime=10s
+go test ./algo -run=^$ -fuzz=^FuzzNthElement$ -fuzztime=10s
 ```
 
-</td></tr></tbody>
+## 许可证
 
-<thead><tr><th colspan="2">删除字符串中的连续空格</th></tr></thead>
-<tbody><tr><td>
-
-```go
-str := "  a  quick   brown  fox  "
-var sb strings.Builder
-var prevIsSpace bool
-for i := 0; i < len(str); i++ {
-  if str[i] != ' ' || !prevIsSpace {
-    sb.WriteByte(str[i])
-  }
-  prevIsSpace = str[i] == ' '
-}
-fmt.Println(sb.String())
-// Output:
-// a quick brown fox
-```
-
-</td><td>
-
-```go
-str := "  a  quick   brown  fox  "
-var sb StringBuilderInserter
-UniqueCopyIf(sBegin(str), sEnd(str), &sb,
-  func(x, y Any) bool { return x.(byte) == ' ' && y.(byte) == ' ' })
-fmt.Println(sb.String())
-// Output:
-// a quick brown fox
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">收集 channel 中最大的 N 个整数</th></tr></thead>
-<tbody><tr><td>
-
-```go
-// 需要手动维护小顶堆。
-```
-
-</td><td>
-
-```go
-top := make([]int, 5)
-PartialSortCopyBy(ChanReader(ch), ChanEOF, begin(top), end(top),
-  func(x, y Any) bool { return x.(int) > y.(int) })
-Copy(begin(top), end(top), IOWriter(os.Stdout, ", "))
-```
-
-</td></tr></tbody>
-
-<thead><tr><th colspan="2">输出 ["a", "b", "c"] 的所有排列</th></tr></thead>
-<tbody><tr><td>
-
-```go
-// 通常需要引入递归来完成。
-```
-
-</td><td>
-
-```go
-s := []string{"a", "b", "c"}
-for ok := true; ok; ok = NextPermutation(begin(s), end(s)) {
-  fmt.Println(s)
-}
-// Output:
-// [a b c]
-// [a c b]
-// [b a c]
-// [b c a]
-// [c a b]
-// [c b a]
-```
-
-</td></tr></tbody>
-</table>
-
-## 致谢
-
-- [cppreference.com](https://en.cppreference.com/)
-- [LLVM libc++](https://libcxx.llvm.org/)
-
-## 开源许可证
-
-BSD 3-Clause
+BSD 3-Clause，详见 [LICENSE](LICENSE)。

--- a/algo/doc.go
+++ b/algo/doc.go
@@ -1,0 +1,5 @@
+// Package algo implements generic algorithms over half-open iterator ranges.
+//
+// Its API follows the C++ standard algorithms while using Go functions for
+// predicates, comparisons, transformations, and generators.
+package algo

--- a/algo/fuzz_test.go
+++ b/algo/fuzz_test.go
@@ -1,0 +1,66 @@
+package algo_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/disksing/iter/v2/algo"
+	iterslices "github.com/disksing/iter/v2/slices"
+)
+
+func FuzzSort(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{1})
+	f.Add([]byte{3, 1, 2, 1, 0, 255})
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		if len(input) > 4096 {
+			t.Skip()
+		}
+
+		got := slices.Clone(input)
+		want := slices.Clone(input)
+		algo.Sort[byte](iterslices.Begin(got), iterslices.End(got))
+		slices.Sort(want)
+
+		if !slices.Equal(got, want) {
+			t.Fatalf("Sort() = %v, want %v", got, want)
+		}
+	})
+}
+
+func FuzzNthElement(f *testing.F) {
+	f.Add([]byte{3, 1, 2}, uint64(0))
+	f.Add([]byte{3, 1, 2}, uint64(1))
+	f.Add([]byte{3, 1, 2}, uint64(2))
+	f.Add([]byte{5, 5, 1, 9, 0, 5}, uint64(99))
+
+	f.Fuzz(func(t *testing.T, input []byte, rawIndex uint64) {
+		if len(input) == 0 || len(input) > 4096 {
+			t.Skip()
+		}
+
+		nth := int(rawIndex % uint64(len(input)))
+		got := slices.Clone(input)
+		want := slices.Clone(input)
+		slices.Sort(want)
+
+		algo.NthElement[byte](
+			iterslices.Begin(got),
+			iterslices.Begin(got).AdvanceN(nth),
+			iterslices.End(got),
+		)
+
+		if got[nth] != want[nth] {
+			t.Fatalf("NthElement()[%d] = %d, want %d; result %v", nth, got[nth], want[nth], got)
+		}
+		for i := range got {
+			if i < nth && got[i] > got[nth] {
+				t.Fatalf("left partition contains %d > pivot %d: %v", got[i], got[nth], got)
+			}
+			if i > nth && got[i] < got[nth] {
+				t.Fatalf("right partition contains %d < pivot %d: %v", got[i], got[nth], got)
+			}
+		}
+	})
+}

--- a/constraints.go
+++ b/constraints.go
@@ -4,6 +4,8 @@
 
 package iter
 
+import "cmp"
+
 // Signed is a constraint that permits any signed integer type.
 // If future releases of Go add new predeclared signed integer types,
 // this constraint will be modified to include them.
@@ -44,13 +46,8 @@ type Complex interface {
 	~complex64 | ~complex128
 }
 
-// Ordered is a constraint that permits any ordered type: any type
-// that supports the operators < <= >= >.
-// If future releases of Go add new ordered types,
-// this constraint will be modified to include them.
-type Ordered interface {
-	Integer | Float | ~string
-}
+// Ordered is the standard library constraint for ordered types.
+type Ordered = cmp.Ordered
 
 // Slice is a constraint that matches slices of any element type.
 type Slice[Elem any] interface {

--- a/cover.sh
+++ b/cover.sh
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-go test -coverprofile=coverage.txt -covermode=atomic ./algo -fuzz-time=5m
-gcov2lcov -infile coverage.txt -outfile lcov.info
+set -euo pipefail
+
+go test -covermode=atomic -coverprofile=coverage.txt ./...
+go tool cover -func=coverage.txt

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,5 @@
+// Package iter defines generic iterator capabilities and common adapters.
+//
+// The algo subpackage provides algorithms over iterator ranges. The slices,
+// lists, and strs subpackages adapt common Go containers to those algorithms.
+package iter

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,21 +1,56 @@
 package iter_test
 
 import (
+	"bytes"
+	"container/list"
 	"fmt"
+	"math/rand"
 
+	"github.com/disksing/iter/v2"
 	"github.com/disksing/iter/v2/algo"
+	"github.com/disksing/iter/v2/lists"
 	"github.com/disksing/iter/v2/slices"
 	"github.com/disksing/iter/v2/strs"
 )
 
-// // Print all list items to console.
-// func ExampleIOWriter() {
-// 	l := list.New()
-// 	GenerateN(ListBackInserter(l), 5, IotaGenerator(1))
-// 	Copy(lBegin(l), lEnd(l), IOWriter(os.Stdout, "->"))
-// 	// Output:
-// 	// 1->2->3->4->5
-// }
+// Sort, deduplicate, and search a slice.
+func Example_sliceAlgorithms() {
+	values := []int{3, 2, 1, 4, 3, 2, 1}
+	slices.Sort(values)
+	values = slices.Unique(values)
+
+	fmt.Println(values)
+	fmt.Println(slices.BinarySearch(values, 3))
+	fmt.Println(slices.LowerBound(values, 3))
+	// Output:
+	// [1 2 3 4]
+	// true
+	// 2
+}
+
+// Print all list items.
+func ExampleIOWriter() {
+	l := list.New()
+	algo.GenerateN(lists.ListBackInserter[int](l), 5, iter.IotaGenerator(1))
+
+	var out bytes.Buffer
+	algo.Copy(lists.Begin[int](l), lists.End[int](l), iter.IOWriter[int](&out, "->"))
+	fmt.Println(out.String())
+	// Output:
+	// 1->2->3->4->5
+}
+
+// Copy values between different container types.
+func ExampleAppender() {
+	src := list.New()
+	algo.GenerateN(lists.ListBackInserter[int](src), 5, iter.IotaGenerator(1))
+
+	var dst []int
+	algo.Copy(lists.Begin[int](src), lists.End[int](src), slices.Appender(&dst))
+	fmt.Println(dst)
+	// Output:
+	// [1 2 3 4 5]
+}
 
 // Reverse a string.
 func ExampleMakeString() {
@@ -39,17 +74,17 @@ func ExampleUnique() {
 	// [1 2 3 4]
 }
 
-// // Sum all integers received from a channel.
-// func ExampleChanReader() {
-// 	ch := make(chan int)
-// 	go func() {
-// 		CopyN(IotaReader(1), 100, ChanWriter(ch))
-// 		close(ch)
-// 	}()
-// 	fmt.Println(Accumulate(ChanReader(ch), ChanEOF, 0))
-// 	// Output:
-// 	// 5050
-// }
+// Sum all integers received from a channel.
+func ExampleChanReader() {
+	ch := make(chan int)
+	go func() {
+		algo.CopyN[int](iter.IotaReader(1), 100, iter.ChanWriter(ch))
+		close(ch)
+	}()
+	fmt.Println(algo.Accumulate(iter.ChanReader(ch), nil, 0))
+	// Output:
+	// 5050
+}
 
 // Remove consecutive spaces in a string.
 func ExampleUniqueCopyIf() {
@@ -62,23 +97,24 @@ func ExampleUniqueCopyIf() {
 	// a quick brown fox
 }
 
-// // Collect N maximum elements from a channel.
-// func ExamplePartialSortCopyBy() {
-// 	ch := make(chan int)
-// 	go func() {
-// 		n := make([]int, 100)
-// 		Iota(begin(n), end(n), 1)
-// 		Shuffle(begin(n), end(n), r)
-// 		Copy(begin(n), end(n), ChanWriter(ch))
-// 		close(ch)
-// 	}()
-// 	top := make([]int, 5)
-// 	PartialSortCopyBy(ChanReader(ch), ChanEOF, begin(top), end(top),
-// 		func(x, y any) bool { return x.(int) > y.(int) })
-// 	Copy(begin(top), end(top), IOWriter(os.Stdout, ", "))
-// 	// Output:
-// 	// 100, 99, 98, 97, 96
-// }
+// Collect N maximum elements from a channel.
+func ExamplePartialSortCopyBy() {
+	ch := make(chan int)
+	go func() {
+		values := make([]int, 100)
+		algo.Iota(slices.Begin(values), slices.End(values), 1)
+		slices.Shuffle(values, rand.New(rand.NewSource(1)))
+		algo.Copy(slices.Begin(values), slices.End(values), iter.ChanWriter(ch))
+		close(ch)
+	}()
+
+	top := make([]int, 5)
+	algo.PartialSortCopyBy(iter.ChanReader(ch), nil, slices.Begin(top), slices.End(top),
+		func(x, y int) bool { return x > y })
+	fmt.Println(top)
+	// Output:
+	// [100 99 98 97 96]
+}
 
 // Print all permutations of ["a", "b", "c"].
 func ExampleNextPermutation() {

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/disksing/iter/v2
 
-go 1.18
+go 1.26.0
 
-require github.com/stretchr/testify v1.4.0
+require github.com/stretchr/testify v1.11.1
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v2 v2.2.2 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/iterator.go
+++ b/iterator.go
@@ -1,8 +1,5 @@
 package iter
 
-// Iter represents an iterator, just an alias of any.
-type Iter[T any] interface{}
-
 type (
 	// Reader is a readable iterator.
 	Reader[T any] interface {
@@ -20,55 +17,55 @@ type (
 )
 
 // Comparable represents an iterator that can be compared.
-type Comparable[It Iter[any]] interface {
+type Comparable[It any] interface {
 	Eq(It) bool
 }
 
 // ForwardMovable represents iterators that can move forward.
-type ForwardMovable[It Iter[any]] interface {
+type ForwardMovable[It any] interface {
 	Next() It
 }
 
 // BackwardMovable represents iterators that can move backward.
-type BackwardMovable[It Iter[any]] interface {
+type BackwardMovable[It any] interface {
 	Prev() It
 }
 
 // InputIter is a readable and forward movable iterator.
-type InputIter[T any, It Iter[T]] interface {
+type InputIter[T any, It any] interface {
 	Reader[T]
 	ForwardMovable[It]
 	Comparable[It]
 }
 
-// OutputIter is a writable and ForwardMovable iterator.
+// OutputIter is a writable iterator.
 //
-// It may not implement the incremental interface, in which case the increment
-// logic is done in Write().
+// If it also implements ForwardMovable, algorithms advance it after each
+// write. Otherwise Write is responsible for advancing the destination.
 type OutputIter[T any] interface {
 	Writer[T]
 }
 
 type (
 	// ForwardIter is an iterator that moves forward.
-	ForwardIter[T any, It Iter[T]] interface {
+	ForwardIter[T any, It any] interface {
 		ForwardMovable[It]
 		Comparable[It]
 		AllowMultiplePass() // a marker indicates it can be multiple passed.
 	}
 	// ForwardReader is an interface that groups ForwardIter and Reader.
-	ForwardReader[T any, It Iter[T]] interface {
+	ForwardReader[T any, It any] interface {
 		ForwardIter[T, It]
 		Reader[T]
 	}
 	// ForwardWriter is an interface that groups ForwardIter and Writer.
-	ForwardWriter[T any, It Iter[T]] interface {
+	ForwardWriter[T any, It any] interface {
 		ForwardIter[T, It]
 		Writer[T]
 	}
 	// ForwardReadWriter is an interface that groups ForwardIter and
 	// ReadWriter.
-	ForwardReadWriter[T any, It Iter[T]] interface {
+	ForwardReadWriter[T any, It any] interface {
 		ForwardIter[T, It]
 		ReadWriter[T]
 	}
@@ -76,22 +73,22 @@ type (
 
 type (
 	// BidiIter is an iterator that moves both forward or backward.
-	BidiIter[T any, It Iter[T]] interface {
+	BidiIter[T any, It any] interface {
 		ForwardIter[T, It]
 		BackwardMovable[It]
 	}
 	// BidiReader is an interface that groups BidiIter and Reader.
-	BidiReader[T any, It Iter[T]] interface {
+	BidiReader[T any, It any] interface {
 		BidiIter[T, It]
 		Reader[T]
 	}
 	// BidiWriter is an interface that groups BidiIter and Writer.
-	BidiWriter[T any, It Iter[T]] interface {
+	BidiWriter[T any, It any] interface {
 		BidiIter[T, It]
 		Writer[T]
 	}
 	// BidiReadWriter is an interface that groups BidiIter and ReadWriter.
-	BidiReadWriter[T any, It Iter[T]] interface {
+	BidiReadWriter[T any, It any] interface {
 		BidiIter[T, It]
 		ReadWriter[T]
 	}
@@ -99,32 +96,32 @@ type (
 
 type (
 	// RandomIter is a random access iterator.
-	RandomIter[T any, It Iter[T]] interface {
+	RandomIter[T any, It any] interface {
 		BidiIter[T, It]
 		AdvanceN(n int) It
 		Distance(It) int
 		Less(It) bool
 	}
 	// RandomReader is an interface that groups RandomIter and Reader.
-	RandomReader[T any, It Iter[T]] interface {
+	RandomReader[T any, It any] interface {
 		RandomIter[T, It]
 		Reader[T]
 	}
 	// RandomWriter is an interface that groups RandomIter and Writer.
-	RandomWriter[T any, It Iter[T]] interface {
+	RandomWriter[T any, It any] interface {
 		RandomIter[T, It]
 		Writer[T]
 	}
 	// RandomReadWriter is an interface that groups RandomIter and
 	// ReadWriter.
-	RandomReadWriter[T any, It Iter[T]] interface {
+	RandomReadWriter[T any, It any] interface {
 		RandomIter[T, It]
 		ReadWriter[T]
 	}
 )
 
 // Distance returns the distance of two iterators.
-func Distance[T any, It Iter[T]](first, last It) int {
+func Distance[T any, It any](first, last It) int {
 	ifirst, ilast := any(first), any(last)
 	if f, ok := ifirst.(RandomIter[T, It]); ok {
 		if l, ok := ilast.(It); ok {
@@ -151,7 +148,7 @@ func Distance[T any, It Iter[T]](first, last It) int {
 }
 
 // AdvanceN moves an iterator by step N.
-func AdvanceN[T any, It Iter[T]](it It, n int) It {
+func AdvanceN[T any, It any](it It, n int) It {
 	if it2, ok := any(it).(RandomIter[T, It]); ok {
 		return it2.AdvanceN(n)
 	}

--- a/lists/doc.go
+++ b/lists/doc.go
@@ -1,0 +1,5 @@
+// Package lists adapts container/list values to the generic iterator model.
+//
+// A container/list stores values as any. Reading an element through
+// Iterator[T] therefore panics when the stored value is not a T.
+package lists

--- a/lists/list_iter.go
+++ b/lists/list_iter.go
@@ -2,31 +2,34 @@ package lists
 
 import "container/list"
 
-// listIter is an iterator works with list.List.
-type listIter[T any] struct {
+// Iterator is a bidirectional iterator over a list.List.
+//
+// list.List stores values as any, so Read panics if the current element does
+// not contain a T.
+type Iterator[T any] struct {
 	l        *list.List
 	e        *list.Element
 	backward bool
 }
 
 // Begin returns an iterator to the front element of the list.
-func Begin[T any](l *list.List) listIter[T] {
-	return listIter[T]{
+func Begin[T any](l *list.List) Iterator[T] {
+	return Iterator[T]{
 		l: l,
 		e: l.Front(),
 	}
 }
 
 // End returns an iterator to the passed last element of the list.
-func End[T any](l *list.List) listIter[T] {
-	return listIter[T]{
+func End[T any](l *list.List) Iterator[T] {
+	return Iterator[T]{
 		l: l,
 	}
 }
 
 // RBegin returns an iterator to the back element of the list.
-func RBegin[T any](l *list.List) listIter[T] {
-	return listIter[T]{
+func RBegin[T any](l *list.List) Iterator[T] {
+	return Iterator[T]{
 		l:        l,
 		e:        l.Back(),
 		backward: true,
@@ -34,34 +37,34 @@ func RBegin[T any](l *list.List) listIter[T] {
 }
 
 // REnd returns an iterator to the passed first element of the list.
-func REnd[T any](l *list.List) listIter[T] {
-	return listIter[T]{
+func REnd[T any](l *list.List) Iterator[T] {
+	return Iterator[T]{
 		l:        l,
 		backward: true,
 	}
 }
 
-func (l listIter[T]) Eq(x listIter[T]) bool {
+func (l Iterator[T]) Eq(x Iterator[T]) bool {
 	return l.e == x.e
 }
 
-func (l listIter[T]) AllowMultiplePass() {}
+func (l Iterator[T]) AllowMultiplePass() {}
 
-func (l listIter[T]) Next() listIter[T] {
+func (l Iterator[T]) Next() Iterator[T] {
 	var e *list.Element
 	if l.backward {
 		e = l.e.Prev()
 	} else {
 		e = l.e.Next()
 	}
-	return listIter[T]{
+	return Iterator[T]{
 		l:        l.l,
 		e:        e,
 		backward: l.backward,
 	}
 }
 
-func (l listIter[T]) Prev() listIter[T] {
+func (l Iterator[T]) Prev() Iterator[T] {
 	var e *list.Element
 	switch {
 	case l.e == nil && l.backward:
@@ -73,45 +76,47 @@ func (l listIter[T]) Prev() listIter[T] {
 	case l.e != nil && !l.backward:
 		e = l.e.Prev()
 	}
-	return listIter[T]{
+	return Iterator[T]{
 		l:        l.l,
 		e:        e,
 		backward: l.backward,
 	}
 }
 
-func (l listIter[T]) Read() T {
+func (l Iterator[T]) Read() T {
 	return l.e.Value.(T)
 }
 
-func (l listIter[T]) Write(x T) {
+func (l Iterator[T]) Write(x T) {
 	l.e.Value = x
 }
 
 // ListBackInserter returns an OutputIter to insert elements to the back of the
 // list.
-func ListBackInserter[T any](l *list.List) listBackInserter[T] {
-	return listBackInserter[T]{l: l}
+func ListBackInserter[T any](l *list.List) BackInserter[T] {
+	return BackInserter[T]{l: l}
 }
 
-type listBackInserter[T any] struct {
+// BackInserter is an output iterator that appends values to a list.List.
+type BackInserter[T any] struct {
 	l *list.List
 }
 
-func (li listBackInserter[T]) Write(x T) {
+func (li BackInserter[T]) Write(x T) {
 	li.l.PushBack(x)
 }
 
 // ListInserter returns an OutputIter to insert elements before a node.
-func ListInserter[T any](l *list.List, e *list.Element) listInserter[T] {
-	return listInserter[T]{l: l, e: e}
+func ListInserter[T any](l *list.List, e *list.Element) Inserter[T] {
+	return Inserter[T]{l: l, e: e}
 }
 
-type listInserter[T any] struct {
+// Inserter is an output iterator that inserts values before a list element.
+type Inserter[T any] struct {
 	l *list.List
 	e *list.Element
 }
 
-func (li listInserter[T]) Write(x T) {
+func (li Inserter[T]) Write(x T) {
 	li.l.InsertBefore(x, li.e)
 }

--- a/lists/list_iter_test.go
+++ b/lists/list_iter_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var _ iter.BidiReadWriter[int, Iterator[int]] = Iterator[int]{}
+
 func listEq[T comparable](assert *assert.Assertions, lst *list.List, v ...T) {
 	end := slices.End(v)
 	assert.True(Equal[T](Begin[T](lst), End[T](lst), slices.Begin(v), &end))

--- a/misc.go
+++ b/misc.go
@@ -6,25 +6,26 @@ import (
 	"math/rand"
 )
 
-type iotaReader[T Numeric] struct {
+// IotaIterator is an input iterator that yields x, x+1, x+2, and so on.
+type IotaIterator[T Numeric] struct {
 	x T
 }
 
-func (r iotaReader[T]) Read() T {
+func (r IotaIterator[T]) Read() T {
 	return r.x
 }
 
-func (r iotaReader[T]) Next() iotaReader[T] {
-	return iotaReader[T]{x: r.x + 1}
+func (r IotaIterator[T]) Next() IotaIterator[T] {
+	return IotaIterator[T]{x: r.x + 1}
 }
 
-func (r iotaReader[T]) Eq(iotaReader[T]) bool {
+func (r IotaIterator[T]) Eq(IotaIterator[T]) bool {
 	return false
 }
 
 // IotaReader creates an InputIter that returns [x, x+1, x+2...).
-func IotaReader[T Numeric, It iotaReader[T]](x T) It {
-	return It{x: x}
+func IotaReader[T Numeric](x T) IotaIterator[T] {
+	return IotaIterator[T]{x: x}
 }
 
 // IotaGenerator creates a Generator that returns [x, x+1, x+2...).
@@ -37,22 +38,23 @@ func IotaGenerator[T Numeric](x T) func() T {
 	}
 }
 
-type repeatReader[T any] struct {
+// RepeatIterator is an input iterator that yields the same value indefinitely.
+type RepeatIterator[T any] struct {
 	x T
 }
 
-func (r repeatReader[T]) Read() T { return r.x }
+func (r RepeatIterator[T]) Read() T { return r.x }
 
-func (r repeatReader[T]) Next() repeatReader[T] { return r }
+func (r RepeatIterator[T]) Next() RepeatIterator[T] { return r }
 
-func (r repeatReader[T]) Eq(repeatReader[T]) bool { return false }
+func (r RepeatIterator[T]) Eq(RepeatIterator[T]) bool { return false }
 
 // RepeatReader creates an InputIter that returns [x, x, x...).
-func RepeatReader[T any](x T) repeatReader[T] {
-	return repeatReader[T]{x: x}
+func RepeatReader[T any](x T) RepeatIterator[T] {
+	return RepeatIterator[T]{x: x}
 }
 
-// RepeatGenerator creates an Generator that returns [x, x, x...).
+// RepeatGenerator creates a Generator that returns [x, x, x...).
 func RepeatGenerator[T any](x T) func() T {
 	return func() T { return x }
 }
@@ -62,26 +64,28 @@ func RandomGenerator[T any](s []T, r *rand.Rand) func() T {
 	return func() T { return s[r.Intn(len(s))] }
 }
 
-type chanReader[T any] struct {
+// ChannelReader is a single-pass input iterator over a channel.
+// A nil *ChannelReader is its end sentinel.
+type ChannelReader[T any] struct {
 	ch    chan T
 	cur   T
 	read1 bool
 	eof   bool
 }
 
-func (cr *chanReader[T]) recv() {
+func (cr *ChannelReader[T]) recv() {
 	v, ok := <-cr.ch
 	cr.cur, cr.read1, cr.eof = v, true, !ok
 }
 
-func (cr *chanReader[T]) Read() T {
+func (cr *ChannelReader[T]) Read() T {
 	if !cr.read1 {
 		cr.recv()
 	}
 	return cr.cur
 }
 
-func (cr *chanReader[T]) Next() *chanReader[T] {
+func (cr *ChannelReader[T]) Next() *ChannelReader[T] {
 	if !cr.read1 {
 		cr.recv()
 	}
@@ -91,42 +95,44 @@ func (cr *chanReader[T]) Next() *chanReader[T] {
 	return cr
 }
 
-func (cr *chanReader[T]) Eq(x *chanReader[T]) bool {
+func (cr *ChannelReader[T]) Eq(x *ChannelReader[T]) bool {
 	if !cr.read1 {
 		cr.recv()
 	}
 	return cr.eof && x == nil
 }
 
-type chanWriter[T any] struct {
+// ChannelWriter is an output iterator that sends values to a channel.
+type ChannelWriter[T any] struct {
 	ch chan T
 }
 
-func (cr *chanWriter[T]) Write(x T) {
+func (cr *ChannelWriter[T]) Write(x T) {
 	cr.ch <- x
 }
 
 // ChanReader returns an InputIter that reads from a channel.
-func ChanReader[T any](c chan T) *chanReader[T] {
-	return &chanReader[T]{
+func ChanReader[T any](c chan T) *ChannelReader[T] {
+	return &ChannelReader[T]{
 		ch: c,
 	}
 }
 
-// ChanWriter returns an OutIter that writes to a channel.
-func ChanWriter[T any](c chan T) *chanWriter[T] {
-	return &chanWriter[T]{
+// ChanWriter returns an OutputIter that writes to a channel.
+func ChanWriter[T any](c chan T) *ChannelWriter[T] {
+	return &ChannelWriter[T]{
 		ch: c,
 	}
 }
 
-type ioWriter struct {
+// OutputWriter is an output iterator that formats values to an io.Writer.
+type OutputWriter[T any] struct {
 	w         io.Writer
 	written   bool
 	delimiter []byte
 }
 
-func (w *ioWriter) Write(x any) {
+func (w *OutputWriter[T]) Write(x T) {
 	if w.written && len(w.delimiter) > 0 {
 		_, err := w.w.Write(w.delimiter)
 		if err != nil {
@@ -143,7 +149,7 @@ func (w *ioWriter) Write(x any) {
 }
 
 // IOWriter returns an OutputIter that writes values to an io.Writer.
-// It panics if meet any error.
-func IOWriter(w io.Writer, delimiter string) *ioWriter {
-	return &ioWriter{w: w, delimiter: []byte(delimiter)}
+// It panics if the writer returns an error.
+func IOWriter[T any](w io.Writer, delimiter string) *OutputWriter[T] {
+	return &OutputWriter[T]{w: w, delimiter: []byte(delimiter)}
 }

--- a/misc_test.go
+++ b/misc_test.go
@@ -1,12 +1,23 @@
 package iter_test
 
 import (
+	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/disksing/iter/v2"
 	. "github.com/disksing/iter/v2"
 	"github.com/disksing/iter/v2/algo"
+	"github.com/disksing/iter/v2/slices"
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	_ iter.InputIter[int, iter.IotaIterator[int]]   = iter.IotaIterator[int]{}
+	_ iter.InputIter[int, iter.RepeatIterator[int]] = iter.RepeatIterator[int]{}
+	_ iter.InputIter[int, *iter.ChannelReader[int]] = (*iter.ChannelReader[int])(nil)
+	_ iter.OutputIter[int]                          = (*iter.ChannelWriter[int])(nil)
+	_ iter.OutputIter[int]                          = (*iter.OutputWriter[int])(nil)
 )
 
 func TestMisc(t *testing.T) {
@@ -67,6 +78,25 @@ func TestChanIterator(t *testing.T) {
 	ch = make(chan int)
 	w := ChanWriter(ch)
 	// See: https://github.com/golang/go/issues/51700
-	// assert.Panics(func() { iter.AdvanceN[int](w, 1) })
+	assert.Panics(func() { iter.AdvanceN[int](w, 1) })
 	assert.Panics(func() { iter.Distance[int](w, nil) })
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestIOWriter(t *testing.T) {
+	assert := assert.New(t)
+	values := []int{1, 2, 3}
+
+	var dst bytes.Buffer
+	algo.Copy(slices.Begin(values), slices.End(values), IOWriter[int](&dst, ", "))
+	assert.Equal("1, 2, 3", dst.String())
+
+	assert.Panics(func() {
+		IOWriter[int](failingWriter{}, "").Write(1)
+	})
 }

--- a/slices/algos.go
+++ b/slices/algos.go
@@ -37,12 +37,12 @@ func CountIf[T any](s []T, pred algo.UnaryPredicate[T]) int {
 	return algo.CountIf(Begin(s), End(s), pred)
 }
 
-func __end_ref[T any](s []T) *sliceIter[T] {
+func __end_ref[T any](s []T) *Iterator[T] {
 	e := End(s)
 	return &e
 }
 
-func __idx[T any](it sliceIter[T]) int {
+func __idx[T any](it Iterator[T]) int {
 	return it.i
 }
 
@@ -110,6 +110,30 @@ func Search[T comparable](s1, s2 []T) int {
 // Elements are compared using the given binary comparer eq.
 func SearchBy[T1, T2 any](s1 []T1, s2 []T2, eq algo.EqComparer[T1, T2]) int {
 	return __idx(algo.SearchBy(Begin(s1), End(s1), Begin(s2), End(s2), eq))
+}
+
+// FindEnd searches for the last occurrence of s2 in s1.
+func FindEnd[T comparable](s1, s2 []T) int {
+	return __idx(algo.FindEnd[T](Begin(s1), End(s1), Begin(s2), End(s2)))
+}
+
+// FindEndBy searches for the last occurrence of s2 in s1.
+//
+// Elements are compared using the given binary comparer eq.
+func FindEndBy[T1, T2 any](s1 []T1, s2 []T2, eq algo.EqComparer[T1, T2]) int {
+	return __idx(algo.FindEndBy(Begin(s1), End(s1), Begin(s2), End(s2), eq))
+}
+
+// SearchN searches for the first sequence of count elements equal to v.
+func SearchN[T comparable](s []T, count int, v T) int {
+	return __idx(algo.SearchN(Begin(s), End(s), count, v))
+}
+
+// SearchNBy searches for the first sequence of count matching elements.
+//
+// Elements are compared with v using the given binary comparer eq.
+func SearchNBy[T1, T2 any](s []T1, count int, v T2, eq algo.EqComparer[T1, T2]) int {
+	return __idx(algo.SearchNBy(Begin(s), End(s), count, v, eq))
 }
 
 // Remove removes all elements equal to v from the slice and returns the new
@@ -196,6 +220,122 @@ func StablePartition[T any](s []T, pred algo.UnaryPredicate[T]) int {
 	return __idx(algo.StablePartitionBidi(Begin(s), End(s), pred))
 }
 
+// PartitionPoint returns the first position for which pred is false in an
+// already partitioned slice.
+func PartitionPoint[T any](s []T, pred algo.UnaryPredicate[T]) int {
+	return __idx(algo.PartitionPoint(Begin(s), End(s), pred))
+}
+
+// IsSorted reports whether s is sorted in ascending order.
+func IsSorted[T iter.Ordered](s []T) bool {
+	return algo.IsSorted[T](Begin(s), End(s))
+}
+
+// IsSortedBy reports whether s is sorted according to less.
+func IsSortedBy[T any](s []T, less algo.LessComparer[T]) bool {
+	return algo.IsSortedBy(Begin(s), End(s), less)
+}
+
+// IsSortedUntil returns the first position at which s stops being sorted.
+// It returns len(s) when s is sorted.
+func IsSortedUntil[T iter.Ordered](s []T) int {
+	return __idx(algo.IsSortedUntil[T](Begin(s), End(s)))
+}
+
+// IsSortedUntilBy returns the first position at which s stops being sorted
+// according to less. It returns len(s) when s is sorted.
+func IsSortedUntilBy[T any](s []T, less algo.LessComparer[T]) int {
+	return __idx(algo.IsSortedUntilBy(Begin(s), End(s), less))
+}
+
+// Sort sorts s in ascending order.
+func Sort[T iter.Ordered](s []T) {
+	algo.Sort[T](Begin(s), End(s))
+}
+
+// SortBy sorts s according to less.
+func SortBy[T any](s []T, less algo.LessComparer[T]) {
+	algo.SortBy(Begin(s), End(s), less)
+}
+
+// StableSort stably sorts s in ascending order.
+func StableSort[T iter.Ordered](s []T) {
+	algo.StableSort[T](Begin(s), End(s))
+}
+
+// StableSortBy stably sorts s according to less.
+func StableSortBy[T any](s []T, less algo.LessComparer[T]) {
+	algo.StableSortBy(Begin(s), End(s), less)
+}
+
+// PartialSort rearranges s so that s[:middle] contains the smallest middle
+// elements in ascending order. middle must be in [0, len(s)].
+func PartialSort[T iter.Ordered](s []T, middle int) {
+	algo.PartialSort[T](Begin(s), Begin(s).AdvanceN(middle), End(s))
+}
+
+// PartialSortBy rearranges s so that s[:middle] contains the first middle
+// elements according to less, in sorted order.
+func PartialSortBy[T any](s []T, middle int, less algo.LessComparer[T]) {
+	algo.PartialSortBy(Begin(s), Begin(s).AdvanceN(middle), End(s), less)
+}
+
+// NthElement rearranges s so the element at nth is the one that would occur
+// there in sorted order. nth must be in [0, len(s)).
+func NthElement[T iter.Ordered](s []T, nth int) {
+	algo.NthElement[T](Begin(s), Begin(s).AdvanceN(nth), End(s))
+}
+
+// NthElementBy rearranges s so the element at nth is the one that would occur
+// there when ordered by less.
+func NthElementBy[T any](s []T, nth int, less algo.LessComparer[T]) {
+	algo.NthElementBy(Begin(s), Begin(s).AdvanceN(nth), End(s), less)
+}
+
+// LowerBound returns the first position at which v could be inserted without
+// violating ascending order.
+func LowerBound[T iter.Ordered](s []T, v T) int {
+	return __idx(algo.LowerBound[T](Begin(s), End(s), v))
+}
+
+// LowerBoundBy returns the first insertion position for v according to less.
+func LowerBoundBy[T any](s []T, v T, less algo.LessComparer[T]) int {
+	return __idx(algo.LowerBoundBy(Begin(s), End(s), v, less))
+}
+
+// UpperBound returns the first position after all elements equal to v.
+func UpperBound[T iter.Ordered](s []T, v T) int {
+	return __idx(algo.UpperBound[T](Begin(s), End(s), v))
+}
+
+// UpperBoundBy returns the first position after all elements equivalent to v
+// according to less.
+func UpperBoundBy[T any](s []T, v T, less algo.LessComparer[T]) int {
+	return __idx(algo.UpperBoundBy(Begin(s), End(s), v, less))
+}
+
+// BinarySearch reports whether sorted s contains v.
+func BinarySearch[T iter.Ordered](s []T, v T) bool {
+	return algo.BinarySearch[T](Begin(s), End(s), v)
+}
+
+// BinarySearchBy reports whether sorted s contains v according to less.
+func BinarySearchBy[T any](s []T, v T, less algo.LessComparer[T]) bool {
+	return algo.BinarySearchBy(Begin(s), End(s), v, less)
+}
+
+// EqualRange returns the lower and upper bounds of v in sorted s.
+func EqualRange[T iter.Ordered](s []T, v T) (int, int) {
+	first, last := algo.EqualRange[T](Begin(s), End(s), v)
+	return __idx(first), __idx(last)
+}
+
+// EqualRangeBy returns the lower and upper bounds of v according to less.
+func EqualRangeBy[T any](s []T, v T, less algo.LessComparer[T]) (int, int) {
+	first, last := algo.EqualRangeBy(Begin(s), End(s), v, less)
+	return __idx(first), __idx(last)
+}
+
 // MaxElement returns the position largest element in a slice.
 func MaxElement[T iter.Ordered](s []T) int {
 	return __idx(algo.MaxElement[T](Begin(s), End(s)))
@@ -220,7 +360,7 @@ func MinElementBy[T any](s []T, less algo.LessComparer[T]) int {
 	return __idx(algo.MinElementBy(Begin(s), End(s), less))
 }
 
-// MinmaxElement returns the position smallest and the lagest element in a slice.
+// MinmaxElement returns the positions of the smallest and largest elements.
 func MinmaxElement[T iter.Ordered](s []T) (int, int) {
 	a, b := algo.MinmaxElement[T](Begin(s), End(s))
 	return __idx(a), __idx(b)
@@ -279,8 +419,13 @@ func LexicographicalCompareThreeWayBy[T any](s1, s2 []T, cmp algo.ThreeWayCompar
 
 // IsPermutation returns true if there exists a permutation of the elements in
 // the slice s1 that makes that range equal to s2.
-func IsPermutation[T iter.Ordered](s1, s2 []T) bool {
+func IsPermutation[T comparable](s1, s2 []T) bool {
 	return algo.IsPermutation[T](Begin(s1), End(s1), Begin(s2), __end_ref(s2))
+}
+
+// IsPermutationBy reports whether s1 is a permutation of s2 according to eq.
+func IsPermutationBy[T any](s1, s2 []T, eq algo.EqComparer[T, T]) bool {
+	return algo.IsPermutationBy(Begin(s1), End(s1), Begin(s2), __end_ref(s2), eq)
 }
 
 // NextPermutation transforms the slice into the next permutation from the set of
@@ -309,4 +454,67 @@ func Accumulate[T iter.Numeric](s []T, v T) T {
 // map/reduce operation on the slice, using v=v+x*y.
 func InnerProduct[T iter.Numeric](s1, s2 []T, v T) T {
 	return algo.InnerProduct(Begin(s1), End(s1), Begin(s2), v)
+}
+
+// IsHeap reports whether s is a max heap.
+func IsHeap[T iter.Ordered](s []T) bool {
+	return algo.IsHeap[T](Begin(s), End(s))
+}
+
+// IsHeapBy reports whether s is a heap according to less.
+func IsHeapBy[T any](s []T, less algo.LessComparer[T]) bool {
+	return algo.IsHeapBy(Begin(s), End(s), less)
+}
+
+// IsHeapUntil returns the first position at which s stops being a max heap.
+// It returns len(s) when s is a heap.
+func IsHeapUntil[T iter.Ordered](s []T) int {
+	return __idx(algo.IsHeapUntil[T](Begin(s), End(s)))
+}
+
+// IsHeapUntilBy returns the first position at which s stops being a heap
+// according to less.
+func IsHeapUntilBy[T any](s []T, less algo.LessComparer[T]) int {
+	return __idx(algo.IsHeapUntilBy(Begin(s), End(s), less))
+}
+
+// MakeHeap rearranges s into a max heap.
+func MakeHeap[T iter.Ordered](s []T) {
+	algo.MakeHeap[T](Begin(s), End(s))
+}
+
+// MakeHeapBy rearranges s into a heap according to less.
+func MakeHeapBy[T any](s []T, less algo.LessComparer[T]) {
+	algo.MakeHeapBy(Begin(s), End(s), less)
+}
+
+// PushHeap adds the final element of s to the max heap in s[:len(s)-1].
+func PushHeap[T iter.Ordered](s []T) {
+	algo.PushHeap[T](Begin(s), End(s))
+}
+
+// PushHeapBy adds the final element of s to the heap in s[:len(s)-1].
+func PushHeapBy[T any](s []T, less algo.LessComparer[T]) {
+	algo.PushHeapBy(Begin(s), End(s), less)
+}
+
+// PopHeap moves the largest element to the end of s and restores the max heap
+// in s[:len(s)-1].
+func PopHeap[T iter.Ordered](s []T) {
+	algo.PopHeap[T](Begin(s), End(s))
+}
+
+// PopHeapBy moves the first heap element to the end of s according to less.
+func PopHeapBy[T any](s []T, less algo.LessComparer[T]) {
+	algo.PopHeapBy(Begin(s), End(s), less)
+}
+
+// SortHeap turns a max heap into an ascending sorted slice.
+func SortHeap[T iter.Ordered](s []T) {
+	algo.SortHeap[T](Begin(s), End(s))
+}
+
+// SortHeapBy turns a heap into a sorted slice according to less.
+func SortHeapBy[T any](s []T, less algo.LessComparer[T]) {
+	algo.SortHeapBy(Begin(s), End(s), less)
 }

--- a/slices/algos_test.go
+++ b/slices/algos_test.go
@@ -1,0 +1,185 @@
+package slices_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	iter "github.com/disksing/iter/v2"
+	iterslices "github.com/disksing/iter/v2/slices"
+)
+
+var _ iter.RandomReadWriter[int, iterslices.Iterator[int]] = iterslices.Iterator[int]{}
+
+func TestSearchFacade(t *testing.T) {
+	values := []int{1, 2, 2, 3, 2, 2, 3, 4}
+
+	if got := iterslices.FindEnd(values, []int{2, 2, 3}); got != 4 {
+		t.Fatalf("FindEnd() = %d, want 4", got)
+	}
+	if got := iterslices.FindEndBy(values, []string{"2", "3"}, func(x int, y string) bool {
+		return string(rune('0'+x)) == y
+	}); got != 5 {
+		t.Fatalf("FindEndBy() = %d, want 5", got)
+	}
+	if got := iterslices.SearchN(values, 2, 2); got != 1 {
+		t.Fatalf("SearchN() = %d, want 1", got)
+	}
+	if got := iterslices.SearchNBy(values, 2, "2", func(x int, y string) bool {
+		return string(rune('0'+x)) == y
+	}); got != 1 {
+		t.Fatalf("SearchNBy() = %d, want 1", got)
+	}
+}
+
+func TestPartitionAndSortFacade(t *testing.T) {
+	partitioned := []int{2, 4, 6, 1, 3, 5}
+	if got := iterslices.PartitionPoint(partitioned, func(x int) bool { return x%2 == 0 }); got != 3 {
+		t.Fatalf("PartitionPoint() = %d, want 3", got)
+	}
+
+	values := []int{9, 1, 5, 3, 7, 2, 8, 6, 4}
+	iterslices.Sort(values)
+	if !slices.IsSorted(values) || !iterslices.IsSorted(values) {
+		t.Fatalf("Sort() result is not sorted: %v", values)
+	}
+	if got := iterslices.IsSortedUntil([]int{1, 3, 2, 4}); got != 2 {
+		t.Fatalf("IsSortedUntil() = %d, want 2", got)
+	}
+
+	desc := []int{1, 4, 2, 3}
+	greater := func(a, b int) bool { return a > b }
+	iterslices.SortBy(desc, greater)
+	if !slices.Equal(desc, []int{4, 3, 2, 1}) || !iterslices.IsSortedBy(desc, greater) {
+		t.Fatalf("SortBy() result = %v", desc)
+	}
+	if got := iterslices.IsSortedUntilBy([]int{4, 3, 1, 2}, greater); got != 3 {
+		t.Fatalf("IsSortedUntilBy() = %d, want 3", got)
+	}
+}
+
+func TestStablePartialAndNthElementFacade(t *testing.T) {
+	type item struct {
+		key int
+		id  string
+	}
+	values := []item{{2, "a"}, {1, "b"}, {2, "c"}, {1, "d"}}
+	iterslices.StableSortBy(values, func(a, b item) bool { return a.key < b.key })
+	want := []item{{1, "b"}, {1, "d"}, {2, "a"}, {2, "c"}}
+	if !slices.Equal(values, want) {
+		t.Fatalf("StableSortBy() = %v, want %v", values, want)
+	}
+
+	partial := []int{8, 3, 7, 4, 2, 6, 5, 1}
+	sorted := slices.Clone(partial)
+	slices.Sort(sorted)
+	iterslices.PartialSort(partial, 4)
+	if !slices.Equal(partial[:4], sorted[:4]) {
+		t.Fatalf("PartialSort() prefix = %v, want %v", partial[:4], sorted[:4])
+	}
+
+	partialDesc := []int{1, 6, 2, 5, 3, 4}
+	iterslices.PartialSortBy(partialDesc, 3, func(a, b int) bool { return a > b })
+	if !slices.Equal(partialDesc[:3], []int{6, 5, 4}) {
+		t.Fatalf("PartialSortBy() prefix = %v", partialDesc[:3])
+	}
+
+	nth := []int{8, 3, 7, 4, 2, 6, 5, 1}
+	iterslices.NthElement(nth, 3)
+	if nth[3] != sorted[3] {
+		t.Fatalf("NthElement() value = %d, want %d", nth[3], sorted[3])
+	}
+	for i := range nth {
+		if i < 3 && nth[i] > nth[3] {
+			t.Fatalf("NthElement() left partition invalid: %v", nth)
+		}
+		if i > 3 && nth[i] < nth[3] {
+			t.Fatalf("NthElement() right partition invalid: %v", nth)
+		}
+	}
+
+	nthDesc := []int{1, 6, 2, 5, 3, 4}
+	iterslices.NthElementBy(nthDesc, 2, func(a, b int) bool { return a > b })
+	if nthDesc[2] != 4 {
+		t.Fatalf("NthElementBy() value = %d, want 4", nthDesc[2])
+	}
+}
+
+func TestBinarySearchFacade(t *testing.T) {
+	values := []int{1, 2, 2, 2, 4, 6}
+
+	if got := iterslices.LowerBound(values, 2); got != 1 {
+		t.Fatalf("LowerBound() = %d, want 1", got)
+	}
+	if got := iterslices.UpperBound(values, 2); got != 4 {
+		t.Fatalf("UpperBound() = %d, want 4", got)
+	}
+	if !iterslices.BinarySearch(values, 4) || iterslices.BinarySearch(values, 3) {
+		t.Fatal("BinarySearch() returned an unexpected result")
+	}
+	first, last := iterslices.EqualRange(values, 2)
+	if first != 1 || last != 4 {
+		t.Fatalf("EqualRange() = (%d, %d), want (1, 4)", first, last)
+	}
+
+	desc := []int{6, 4, 2, 2, 2, 1}
+	greater := func(a, b int) bool { return a > b }
+	if got := iterslices.LowerBoundBy(desc, 2, greater); got != 2 {
+		t.Fatalf("LowerBoundBy() = %d, want 2", got)
+	}
+	if got := iterslices.UpperBoundBy(desc, 2, greater); got != 5 {
+		t.Fatalf("UpperBoundBy() = %d, want 5", got)
+	}
+	if !iterslices.BinarySearchBy(desc, 4, greater) {
+		t.Fatal("BinarySearchBy() did not find 4")
+	}
+	first, last = iterslices.EqualRangeBy(desc, 2, greater)
+	if first != 2 || last != 5 {
+		t.Fatalf("EqualRangeBy() = (%d, %d), want (2, 5)", first, last)
+	}
+}
+
+func TestHeapFacade(t *testing.T) {
+	values := []int{3, 1, 4, 2, 5}
+	iterslices.MakeHeap(values)
+	if !iterslices.IsHeap(values) || iterslices.IsHeapUntil(values) != len(values) {
+		t.Fatalf("MakeHeap() result is not a heap: %v", values)
+	}
+
+	values = append(values, 6)
+	iterslices.PushHeap(values)
+	if !iterslices.IsHeap(values) || values[0] != 6 {
+		t.Fatalf("PushHeap() result is invalid: %v", values)
+	}
+
+	iterslices.PopHeap(values)
+	if values[len(values)-1] != 6 || !iterslices.IsHeap(values[:len(values)-1]) {
+		t.Fatalf("PopHeap() result is invalid: %v", values)
+	}
+
+	heap := values[:len(values)-1]
+	iterslices.SortHeap(heap)
+	if !slices.IsSorted(heap) {
+		t.Fatalf("SortHeap() result is not sorted: %v", heap)
+	}
+
+	minHeap := []int{5, 3, 4, 1, 2}
+	greater := func(a, b int) bool { return a > b }
+	iterslices.MakeHeapBy(minHeap, greater)
+	if !iterslices.IsHeapBy(minHeap, greater) ||
+		iterslices.IsHeapUntilBy(minHeap, greater) != len(minHeap) {
+		t.Fatalf("MakeHeapBy() result is not a min heap: %v", minHeap)
+	}
+	iterslices.SortHeapBy(minHeap, greater)
+	if !slices.IsSortedFunc(minHeap, func(a, b int) int { return b - a }) {
+		t.Fatalf("SortHeapBy() result is not descending: %v", minHeap)
+	}
+}
+
+func TestIsPermutationByFacade(t *testing.T) {
+	left := []string{"A", "b", "C"}
+	right := []string{"c", "B", "a"}
+	if !iterslices.IsPermutationBy(left, right, strings.EqualFold) {
+		t.Fatal("IsPermutationBy() = false, want true")
+	}
+}

--- a/slices/doc.go
+++ b/slices/doc.go
@@ -1,0 +1,4 @@
+// Package slices provides direct generic APIs for algorithms over slices.
+//
+// It also exposes Iterator and Appender for using slices with package algo.
+package slices

--- a/slices/slice_iter.go
+++ b/slices/slice_iter.go
@@ -5,68 +5,69 @@ import (
 	"strings"
 )
 
-type sliceIter[T any] struct {
+// Iterator is a random-access iterator over a slice.
+type Iterator[T any] struct {
 	s    []T
 	i    int
 	step int
 }
 
 // Begin returns an iterator to the front element of the slice.
-func Begin[T any, It sliceIter[T]](s []T) It {
-	return It{s, 0, 1}
+func Begin[T any](s []T) Iterator[T] {
+	return Iterator[T]{s: s, i: 0, step: 1}
 }
 
 // End returns an iterator to the passed last element of the slice.
-func End[T any, It sliceIter[T]](s []T) It {
-	return It{s, len(s), 1}
+func End[T any](s []T) Iterator[T] {
+	return Iterator[T]{s: s, i: len(s), step: 1}
 }
 
 // RBegin returns an iterator to the back element of the slice.
-func RBegin[T any, It sliceIter[T]](s []T) It {
-	return It{s, len(s) - 1, -1}
+func RBegin[T any](s []T) Iterator[T] {
+	return Iterator[T]{s: s, i: len(s) - 1, step: -1}
 }
 
 // REnd returns an iterator to the passed first element of the slice.
-func REnd[T any, It sliceIter[T]](s []T) It {
-	return It{s, -1, -1}
+func REnd[T any](s []T) Iterator[T] {
+	return Iterator[T]{s: s, i: -1, step: -1}
 }
 
-func (it sliceIter[T]) Read() T {
+func (it Iterator[T]) Read() T {
 	return it.s[it.i]
 }
 
-func (it sliceIter[T]) Write(v T) {
+func (it Iterator[T]) Write(v T) {
 	it.s[it.i] = v
 }
 
-func (it sliceIter[T]) Eq(it2 sliceIter[T]) bool {
+func (it Iterator[T]) Eq(it2 Iterator[T]) bool {
 	return it.i == it2.i
 }
 
-func (it sliceIter[T]) Less(it2 sliceIter[T]) bool {
+func (it Iterator[T]) Less(it2 Iterator[T]) bool {
 	if it.step < 0 {
 		return it.i > it2.i
 	}
 	return it.i < it2.i
 }
 
-func (it sliceIter[T]) Next() sliceIter[T] {
+func (it Iterator[T]) Next() Iterator[T] {
 	return it.AdvanceN(1)
 }
 
-func (it sliceIter[T]) Prev() sliceIter[T] {
+func (it Iterator[T]) Prev() Iterator[T] {
 	return it.AdvanceN(-1)
 }
 
-func (it sliceIter[T]) AdvanceN(n int) sliceIter[T] {
-	return sliceIter[T]{
+func (it Iterator[T]) AdvanceN(n int) Iterator[T] {
+	return Iterator[T]{
 		s:    it.s,
 		i:    it.i + n*it.step,
 		step: it.step,
 	}
 }
 
-func (it sliceIter[T]) String() string {
+func (it Iterator[T]) String() string {
 	dir := "->"
 	if it.step < 0 {
 		dir = "<-"
@@ -81,24 +82,25 @@ func (it sliceIter[T]) String() string {
 	return fmt.Sprintf("[%v](len=%d,cap=%d)@%d%s", strings.Join(buf, ","), len(it.s), cap(it.s), it.i, dir)
 }
 
-func (it sliceIter[T]) AllowMultiplePass() {}
+func (it Iterator[T]) AllowMultiplePass() {}
 
-func (it sliceIter[T]) Distance(it2 sliceIter[T]) int {
+func (it Iterator[T]) Distance(it2 Iterator[T]) int {
 	return (it2.i - it.i) * it.step
 }
 
-type sliceBackInserter[T any] struct {
+// BackInserter is an output iterator that appends values to a slice.
+type BackInserter[T any] struct {
 	s *[]T
 }
 
 // Appender returns an OutputIter to append elements to the back of the
 // slice.
-func Appender[T any](s *[]T) sliceBackInserter[T] {
-	return sliceBackInserter[T]{
+func Appender[T any](s *[]T) BackInserter[T] {
+	return BackInserter[T]{
 		s: s,
 	}
 }
 
-func (bi sliceBackInserter[T]) Write(x T) {
+func (bi BackInserter[T]) Write(x T) {
 	*bi.s = append(*bi.s, x)
 }

--- a/strs/doc.go
+++ b/strs/doc.go
@@ -1,0 +1,5 @@
+// Package strs provides byte iterators over strings and string output helpers.
+//
+// Convert a string to []rune and use package slices when iteration by rune is
+// required.
+package strs

--- a/strs/str_iter.go
+++ b/strs/str_iter.go
@@ -7,25 +7,25 @@ import (
 	"github.com/disksing/iter/v2"
 )
 
-// stringIter is the iterator to access a string in bytes. To travise a string
-// by rune, convert the string to []rune then use SliceIter.
-type stringIter struct {
+// Iterator accesses the bytes in a string. To traverse runes, convert the
+// string to []rune and use slices.Iterator.
+type Iterator struct {
 	s    string
 	i    int
 	step int
 }
 
 // Begin returns an iterator to the front element of the string.
-func Begin(s string) stringIter {
-	return stringIter{
+func Begin(s string) Iterator {
+	return Iterator{
 		s:    s,
 		step: 1,
 	}
 }
 
 // End returns an iterator to the passed last element of the string.
-func End(s string) stringIter {
-	return stringIter{
+func End(s string) Iterator {
+	return Iterator{
 		s:    s,
 		i:    len(s),
 		step: 1,
@@ -33,8 +33,8 @@ func End(s string) stringIter {
 }
 
 // RBegin returns an iterator to the back element of the string.
-func RBegin(s string) stringIter {
-	return stringIter{
+func RBegin(s string) Iterator {
+	return Iterator{
 		s:    s,
 		i:    len(s) - 1,
 		step: -1,
@@ -42,15 +42,15 @@ func RBegin(s string) stringIter {
 }
 
 // REnd returns an iterator to the passed first element of the string.
-func REnd(s string) stringIter {
-	return stringIter{
+func REnd(s string) Iterator {
+	return Iterator{
 		s:    s,
 		i:    -1,
 		step: -1,
 	}
 }
 
-func (it stringIter) String() string {
+func (it Iterator) String() string {
 	dir := "->"
 	if it.step < 0 {
 		dir = "<-"
@@ -58,37 +58,37 @@ func (it stringIter) String() string {
 	return fmt.Sprintf("%s@%d%s", it.s, it.i, dir)
 }
 
-func (it stringIter) Read() byte {
+func (it Iterator) Read() byte {
 	return it.s[it.i]
 }
 
-func (it stringIter) Eq(it2 stringIter) bool {
+func (it Iterator) Eq(it2 Iterator) bool {
 	return it.i == it2.i
 }
 
-func (it stringIter) AllowMultiplePass() {}
+func (it Iterator) AllowMultiplePass() {}
 
-func (it stringIter) Next() stringIter {
+func (it Iterator) Next() Iterator {
 	return it.AdvanceN(1)
 }
 
-func (it stringIter) Prev() stringIter {
+func (it Iterator) Prev() Iterator {
 	return it.AdvanceN(-1)
 }
 
-func (it stringIter) AdvanceN(n int) stringIter {
-	return stringIter{
+func (it Iterator) AdvanceN(n int) Iterator {
+	return Iterator{
 		s:    it.s,
 		i:    it.i + n*it.step,
 		step: it.step,
 	}
 }
 
-func (it stringIter) Distance(it2 stringIter) int {
+func (it Iterator) Distance(it2 Iterator) int {
 	return (it2.i - it.i) * it.step
 }
 
-func (it stringIter) Less(it2 stringIter) bool {
+func (it Iterator) Less(it2 Iterator) bool {
 	if it.step > 0 {
 		return it.i < it2.i
 	}
@@ -119,7 +119,7 @@ func (si *StringBuilderInserter[T]) Write(x T) {
 	}
 }
 
-// MakeString creates a string by range spesified by [first, last). The value
+// MakeString creates a string from the range specified by [first, last). The value
 // type should be byte or rune.
 func MakeString[T byte | rune, It iter.ForwardReader[T, It]](first, last It) string {
 	var s strings.Builder

--- a/strs/str_iter_test.go
+++ b/strs/str_iter_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var _ iter.RandomReader[byte, Iterator] = Iterator{}
+
 func TestStringIterator(t *testing.T) {
 	assert := assert.New(t)
 	s := "abcdefg"


### PR DESCRIPTION
## Summary

- harden the generic iterator contracts and adapters, including a usable `IOWriter[T]` and exported concrete iterator types
- add high-priority direct slice APIs for sorting, searching, partitioning, binary search, and heap operations
- refresh examples, package documentation, English and Chinese READMEs, dependencies, coverage tooling, and CI
- add real fuzz targets for `Sort` and `NthElement`

## Validation

- `go mod verify`
- `go test -shuffle=on -count=5 ./...`
- `go test -race -covermode=atomic -coverprofile=coverage.txt ./...`
- `go vet ./...`
- Actionlint on `.github/workflows/test.yml`
- 10-second fuzz smoke tests for `FuzzSort` and `FuzzNthElement`
- `git diff --check`

Staticcheck reports the same 16 pre-existing findings as `master@1f204b1`; this change adds no new findings.

## Scope

This PR intentionally does not add a standard-library `iter.Seq` facade, redesign the cursor architecture, create a v2 tag, or publish a release.